### PR TITLE
Fix avr-smoke compile failures on atmega328p and attiny84

### DIFF
--- a/include/etl/architecture/ioports_ATmega328P.h
+++ b/include/etl/architecture/ioports_ATmega328P.h
@@ -1457,103 +1457,6 @@ public:
 template<> struct is_uart_rxd_capable<PinD2> : std::true_type {};
 template<> struct is_uart_txd_capable<PinD3> : std::true_type {};
 
-class Uart1Driver {
-    static const uint8_t BufferSize = 32;
-    static uint8_t readIndex, writeIndex;
-protected:
-    static void start(uint32_t BAUD_RATE, FrameFormat FRAME_FORMAT) {
-        readIndex = 0;
-        writeIndex = 0;
-        float speedRate = BAUD_RATE > 57600 ? BAUD_RATE * 8 : BAUD_RATE * 16;
-        auto spd = static_cast<uint16_t>(((Device::McuFrequency / speedRate)) - 0.5);
-        UBRR1H = spd>>8 &0b1111;
-        UBRR1L = spd;
-        
-        auto nbBits = (FRAME_FORMAT & FrameFormat::NbBitsMask) >> 3;
-        auto nbBits1 = (nbBits & 0b10) == 0b10;
-        auto nbBits0 = (nbBits & 0b1) == 0b1;
-        
-        auto parityMode = (FRAME_FORMAT & FrameFormat::ParityMask) >> 1;
-        auto parity0 = parityMode == 0b10;
-        auto parity1 = parityMode != 0b00;
-         
-        auto stopBit = (FRAME_FORMAT & FrameFormat::StopBitMask) >> 0;
-        
-        if (BAUD_RATE > 57600)
-            UCSR1A = 1<<U2X1;
-        UCSR1C = (nbBits1<<UCSZ11) | (nbBits0<<UCSZ10) | (parity0<<UPM10) | (parity1<<UPM11) | (stopBit<<USBS1);
-        UCSR1B = (1<<RXEN1) | (1<<TXEN1) | (1<<RXCIE1);
-     }
-
-    using Queue =  etl::CircularBuffer<uint8_t,BufferSize>;
-    static Queue fifo;
-    using ReceiveCallback = void(*)(uint8_t);
-    static ReceiveCallback receiveCallback;
-
-public:
-    static void writeAsync(uint8_t datum) {
-        if (UCSR1A & (1<<UDRE1)) {
-            UDR1 = datum;
-        }
-        else {
-            fifo.push_back(datum);
-            UCSR1B |= 1<<UDRIE1;
-        }
-    }
-
-
-    struct Isr {
-        static void receiveComplete() IOPORTS_IRQ_HANDLER(USART1_RX_vect, signal);
-        static void fifoEmpty() IOPORTS_IRQ_HANDLER(USART1_UDRE_vect, signal);
-    };
-};
-
-uint8_t Uart1Driver::readIndex = 0;
-uint8_t Uart1Driver::writeIndex = 0;
-Uart1Driver::Queue Uart1Driver::fifo;
-Uart1Driver::ReceiveCallback Uart1Driver::receiveCallback = nullptr;
-
-void Uart1Driver::Isr::fifoEmpty() {
-      if (!fifo.empty()) {
-        while((UCSR1A & (1<<UDRE1)) && !fifo.empty()) {
-            UDR1 =  fifo.pop_front();
-         }
-       } else {
-        UCSR1B &= ~(1<<UDRIE1);
-       }
-  }
-
-void Uart1Driver::Isr::receiveComplete() {
-    if (receiveCallback) {
-        receiveCallback(UDR1);
-    }
-}
-
-template<uint32_t BAUD_RATE, FrameFormat FRAME_FORMAT, typename CharType>
-class Uart1 : public Uart1Driver {
-public:
-    using ReceiveCallback = void(*)(CharType);
-    enum class StatusFlags : uint8_t {
-        ReceiveComplete = 1<<RXC1,
-        TransmitComplete = 1<<TXC1,
-        FrameError = 1<<FE1,
-        DataOverrun = 1<<DOR1,
-        ParityError = 1<<UPE1,
-    };
-    
-    static void start() { Uart1Driver::start(BAUD_RATE, FRAME_FORMAT); }
-    static void start(ReceiveCallback func) {
-        receiveCallback = static_cast<Uart1Driver::ReceiveCallback>(func);
-        start();
-    }
-    
-    static void write(CharType datum) {
-        while(fifo.size() >= (BufferSize-1)) {
-            Device::delayTicks(Device::McuFrequency/(BAUD_RATE/8));
-        }
-        writeAsync(datum);
-    }
-};
 #ifdef PCICR
 struct PinChangeControlRegister {
   static void setBits(uint8_t mask)   { PCICR |= mask; }
@@ -1569,14 +1472,14 @@ struct PinChangeMask0 {
 
 struct PinChangeIRQ0 {
   static void enableSource(uint8_t PCINT) {
-    PinChangeControlRegister::SetBits(1<<PCIE0);
-    PinChangeMask0::SetBits(1<<PCINT);
+    PinChangeControlRegister::setBits(1<<PCIE0);
+    PinChangeMask0::setBits(1<<PCINT);
   }
 
   static void disableSource(uint8_t PCINT) {
-    PinChangeMask0::ClearBits(1<<PCINT);
+    PinChangeMask0::clearBits(1<<PCINT);
     if (0 == PinChangeMask0::Get()) {
-      PinChangeControlRegister::ClearBits(1<<PCIE0);
+      PinChangeControlRegister::clearBits(1<<PCIE0);
     }
   }
 
@@ -1602,14 +1505,14 @@ struct PinChangeMask1 {
 
 struct PinChangeIRQ1 {
   static void enableSource(uint8_t PCINT) {
-    PinChangeControlRegister::SetBits(1<<PCIE1);
-    PinChangeMask1::SetBits(1<<PCINT);
+    PinChangeControlRegister::setBits(1<<PCIE1);
+    PinChangeMask1::setBits(1<<PCINT);
   }
 
   static void disableSource(uint8_t PCINT) {
-    PinChangeMask1::ClearBits(1<<PCINT);
+    PinChangeMask1::clearBits(1<<PCINT);
     if (0 == PinChangeMask1::Get()) {
-      PinChangeControlRegister::ClearBits(1<<PCIE1);
+      PinChangeControlRegister::clearBits(1<<PCIE1);
     }
   }
 
@@ -1635,14 +1538,14 @@ struct PinChangeMask2 {
 
 struct PinChangeIRQ2 {
   static void enableSource(uint8_t PCINT) {
-    PinChangeControlRegister::SetBits(1<<PCIE2);
-    PinChangeMask2::SetBits(1<<PCINT);
+    PinChangeControlRegister::setBits(1<<PCIE2);
+    PinChangeMask2::setBits(1<<PCINT);
   }
 
   static void disableSource(uint8_t PCINT) {
-    PinChangeMask2::ClearBits(1<<PCINT);
+    PinChangeMask2::clearBits(1<<PCINT);
     if (0 == PinChangeMask2::Get()) {
-      PinChangeControlRegister::ClearBits(1<<PCIE2);
+      PinChangeControlRegister::clearBits(1<<PCIE2);
     }
   }
 

--- a/include/etl/architecture/ioports_ATtiny84.h
+++ b/include/etl/architecture/ioports_ATtiny84.h
@@ -639,60 +639,6 @@ struct PinB0 {
 };
 
 
-struct SpiSpcr {
-
-  /// Assigns a value to SPCR
-  /// @param[in] value value affected to SPCR
-  static void Assign(uint8_t value)  { SPCR = value; }
-
-  /// Sets masked bits in SPCR
-  /// @param[in] mask bits to set
-  static void Set(uint8_t mask)      { SPCR |= mask; }
-
-  /// Clears masked bits in SPCR
-  /// @param[in] mask bits to clear
-  static void Clear(uint8_t mask)    { SPCR &= ~mask; }
-  static uint8_t Get()               { return SPCR; }
-  static bool TestBits(uint8_t mask) { return SPCR & mask; }
-  void operator=(uint8_t value)      { SPCR = value; }
-};
-
-struct SpiSpdr {
-
-  /// Assigns a value to SPDR
-  /// @param[in] value value affected to SPDR
-  static void Assign(uint8_t value)  { SPDR = value; }
-
-  /// Sets masked bits in SPDR
-  /// @param[in] mask bits to set
-  static void Set(uint8_t mask)      { SPDR |= mask; }
-
-  /// Clears masked bits in SPDR
-  /// @param[in] mask bits to clear
-  static void Clear(uint8_t mask)    { SPDR &= ~mask; }
-  static uint8_t Get()               { return SPDR; }
-  static bool TestBits(uint8_t mask) { return SPDR & mask; }
-  void operator=(uint8_t value)      { SPDR = value; }
-};
-
-struct SpiSpsr {
-
-  /// Assigns a value to SPSR
-  /// @param[in] value value affected to SPSR
-  static void Assign(uint8_t value)  { SPSR = value; }
-
-  /// Sets masked bits in SPSR
-  /// @param[in] mask bits to set
-  static void Set(uint8_t mask)      { SPSR |= mask; }
-
-  /// Clears masked bits in SPSR
-  /// @param[in] mask bits to clear
-  static void Clear(uint8_t mask)    { SPSR &= ~mask; }
-  static uint8_t Get()               { return SPSR; }
-  static bool TestBits(uint8_t mask) { return SPSR & mask; }
-  void operator=(uint8_t value)      { SPSR = value; }
-};
-
 struct Timer0 {
   using value_type = uint8_t;
   static const uint8_t timer_width = 8;

--- a/libstd/include/h/traits_primary_types.h
+++ b/libstd/include/h/traits_primary_types.h
@@ -36,6 +36,8 @@
 #include <libstd/include/cstddef>
 
 namespace ETLSTD {
+template<typename> struct is_function;
+
 namespace etlHelper {
 template<typename> struct is_type_entier        : false_type { };
 template<> struct is_type_entier<bool>          : true_type  { };
@@ -56,10 +58,10 @@ template<typename T> struct is_pointeur         : false_type { };
 template<typename T> struct is_pointeur<T*>     : true_type  { };
 template<typename T> struct is_mb_pointeur      : false_type { };
 template<typename T, typename U> struct is_mb_pointeur<T U::*> : true_type { };
-template<typename T> struct is_mb_fonction_pointeur : std::false_type {};
-template<typename T, typename U> struct is_mb_fonction_pointeur<T U::*> : std::is_function<T> {}
+template<typename T> struct is_mb_fonction_pointeur : false_type {};
+template<typename T, typename U> struct is_mb_fonction_pointeur<T U::*> : is_function<T> {};
 
-;} // namespace etlHelper
+} // namespace etlHelper
 
 
 template<typename T> struct is_void : integral_constant<bool, is_same<void, remove_cv_t<T>>::value> { };


### PR DESCRIPTION
## Summary

master's CI has been red since `eb1dba3` ("Modernize build and AVR workflow") was pushed directly
to master, bypassing PR review. That commit added the `avr-smoke` CI job — the first thing to
ever compile real AVR-target code for this project — and it surfaced four pre-existing bugs
(dating to 2014-2018, per `git blame`) that simply had no compiler exercising them until now.

Root-caused in #99; this PR fixes all four:

- `libstd/include/h/traits_primary_types.h`: `is_mb_fonction_pointeur` used hardcoded
  `std::false_type`/`std::is_function<T>` before this file's own `is_function` was even declared.
  Worked by accident on host builds (real `<type_traits>` gets pulled in transitively elsewhere);
  fails standalone on freestanding avr-g++. Forward-declare `is_function` and use the file's own
  unqualified names, per this repo's own `ETLSTD::`-over-`std::` convention.
- `ioports_ATmega328P.h`: removed the dead `Uart1Driver`/`Uart1` classes — they reference a second
  USART that doesn't exist on this single-USART chip, and are unreferenced anywhere in the repo.
- `ioports_ATmega328P.h`: fixed `PinChangeIRQ0/1/2` calling PascalCase `SetBits`/`ClearBits` on
  helpers that only ever defined lowercase `setBits`/`clearBits`.
- `ioports_ATtiny84.h`: removed the `SpiSpcr`/`SpiSpdr`/`SpiSpsr` block — it references full
  hardware-SPI registers that don't exist on the ATtiny84 (USI only), copy-pasted boilerplate that
  is unused dead code here.

No behavior change intended for any working configuration — this only removes unreachable dead
code and fixes a libstd forward-reference/naming bug that AVR builds couldn't previously reach.

Fixes #99

## Test plan

- [x] `cmake -S . -B build && cmake --build build && ctest --test-dir build --output-on-failure`
      passes locally (host GCC 13.4) — no test regressions from the fix.
- [ ] CI `avr-smoke (atmega328p, 16000000UL)` and `avr-smoke (attiny84, 8000000UL)` go green (no
      local avr-g++ available in this environment to verify beforehand; relying on CI here).
