### PR TITLE
libstd: keep queue adapter-only

### DIFF
--- a/libstd/include/queue
+++ b/libstd/include/queue
@@ -1,9 +1,9 @@
 /// @file queue
 /// @data 20/09/2016 17:40:53
-/// @author Ambroise Leclerc and Cécile Gomes
+/// @author Ambroise Leclerc and Cï¿½cile Gomes
 /// @brief Container adapter that gives the functionality of a fifo.
 //
-// Copyright (c) 2014, Ambroise Leclerc and Cécile Gomes
+// Copyright (c) 2014, Ambroise Leclerc and Cï¿½cile Gomes
 //   All rights reserved.
 //
 //   Redistribution and use in source and binary forms, with or without
@@ -35,8 +35,8 @@
 
 namespace ETLSTD {
 
-template<typename T, typename Container /* TODO = ETLSTD::deque<T>*/>
-class queue {
+// queue stays adapter-only; use etl::CircularBuffer<T,N> as Container for fixed-capacity storage.
+template <typename T, typename Container> class queue {
 public:
     using container_type = Container;
     using value_type = typename Container::value_type;
@@ -44,44 +44,30 @@ public:
     using reference = typename Container::reference;
     using const_reference = typename Container::const_reference;
 
-    bool empty() const              { return container.empty(); }
-    size_type size() const          { return container.size(); }
-    reference front()				{ return container.front(); }
-	const_reference front() const	{ return container.front(); }
-	reference back()				{ return container.back(); }
-	const_reference back() const	{ return container.back(); }
+    bool empty() const { return container.empty(); }
+    size_type size() const { return container.size(); }
+    reference front() { return container.front(); }
+    const_reference front() const { return container.front(); }
+    reference back() { return container.back(); }
+    const_reference back() const { return container.back(); }
 
-    void pop()                      { container.pop_front(); }
+    void pop() { container.pop_front(); }
 
-    void push(const value_type& element) {
-        container.push_back(element);
-    }
+    void push(const value_type &element) { container.push_back(element); }
 
-    void push(value_type&& element) {
-        container.push_back(move(element));
-    }
+    void push(value_type &&element) { container.push_back(move(element)); }
 
-    template<typename... Args>
-    void emplace(Args&& ... args) {
-        container.emplace_back(forward<Args>(args)...);
-    }
+    template <typename... Args> void emplace(Args &&...args) { container.emplace_back(forward<Args>(args)...); }
 
-    void swap(queue& right) {
-        Container* pointeurLeft = &container;
-        Container* pointeurRight = &right.container;
-        Container temp = *pointeurLeft;
-        *pointeurLeft = *pointeurRight;
-        *pointeurRight = temp;
+    void swap(queue &right) {
+        using ETLSTD::swap;
+        swap(container, right.container);
     }
 
 protected:
     Container container;
 };
 
-
-template<typename T, typename Container>
-void swap(queue<T,Container>& lhs, queue<T,Container>& rhs) { lhs.swap(rhs); }
-
-	
+template <typename T, typename Container> void swap(queue<T, Container> &lhs, queue<T, Container> &rhs) { lhs.swap(rhs); }
 
 } // namespace ETLSTD

--- a/libstd/include/queue
+++ b/libstd/include/queue
@@ -31,12 +31,16 @@
 //  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 //  POSSIBILITY OF SUCH DAMAGE.
 #pragma once
+#include <libstd/include/type_traits>
 #include <libstd/include/utility>
 
 namespace ETLSTD {
 
 // queue stays adapter-only; use etl::CircularBuffer<T,N> as Container for fixed-capacity storage.
 template <typename T, typename Container> class queue {
+    static_assert(is_same<T, typename Container::value_type>::value,
+                  "queue<T, Container> : T must be the same type as Container::value_type");
+
 public:
     using container_type = Container;
     using value_type = typename Container::value_type;

--- a/test/CircularBuffer.cpp
+++ b/test/CircularBuffer.cpp
@@ -97,7 +97,7 @@ SCENARIO("CircularBuffer holding unique_ptrs") {
     REQUIRE(Element::nbCreated == 24);
     REQUIRE(Element::nbActive == 15);
 
-    queue<uint8_t, Buffer> fifo;
+    queue<unique_ptr<Element>, Buffer> fifo;
     for (auto &&elem : source)
         fifo.push(move(elem));
 }

--- a/test/libstd/queue.cpp
+++ b/test/libstd/queue.cpp
@@ -92,7 +92,7 @@ public:
     }
     template <typename... Args> void emplace_back(Args &&...args) {
         mockStatus += Emplace;
-        new (&elemB) uint8_t(std::forward<Args>(args)...);
+        new (&elemB) uint8_t(ETLSTD::forward<Args>(args)...);
     }
     enum method {
         Size = 1,

--- a/test/libstd/queue.cpp
+++ b/test/libstd/queue.cpp
@@ -34,9 +34,10 @@
 
 #define __Mock_Mock__
 #define ETLSTD etlstd
-#include <libstd/include/queue>
+#include <etl/CircularBuffer.h>
 #include <libstd/include/cstddef>
 #include <libstd/include/memory>
+#include <libstd/include/queue>
 
 using namespace ETLSTD;
 
@@ -46,20 +47,65 @@ class SequenceContainerMock {
 public:
     using value_type = uint8_t;
     using size_type = ETLSTD::size_t;
-    using reference = value_type&;
-    using const_reference = const value_type&;
+    using reference = value_type &;
+    using const_reference = const value_type &;
 
-    SequenceContainerMock() : elemF(8), elemB(2), contSize(0) { }
-    bool empty() const { mockStatus += Empty; return false; }
-    size_type size() const { mockStatus += Size; return contSize; }
-    reference front() { mockStatus += Front; return elemF; }
-    reference back() { mockStatus += Back; return elemB; }
-    void push_back(const_reference elem) { mockStatus += PushBack; contSize++; elemB = elem; }
-    void pop_front() { mockStatus += PopFront; contSize--; }
-    template<typename... Args>
-    void emplace_back(Args&& ... args) { mockStatus += Emplace; new(&elemB) uint8_t(std::forward<Args>(args)...); }
-    enum method { Size = 1, Front = 10, Back = 100, PushBack = 1000, PopFront = 10000,
-                  Empty = 100000, Emplace = 1000000, Swap = 10000000 };
+    SequenceContainerMock() : elemF(8), elemB(2), contSize(0) {}
+    SequenceContainerMock(const SequenceContainerMock &) = delete;
+    SequenceContainerMock &operator=(const SequenceContainerMock &) = delete;
+    SequenceContainerMock(SequenceContainerMock &&other) noexcept
+        : elemF(other.elemF), elemB(other.elemB), contSize(other.contSize) {
+        mockStatus += MoveConstruct;
+    }
+    SequenceContainerMock &operator=(SequenceContainerMock &&other) noexcept {
+        mockStatus += MoveAssign;
+        elemF = other.elemF;
+        elemB = other.elemB;
+        contSize = other.contSize;
+        return *this;
+    }
+
+    bool empty() const {
+        mockStatus += Empty;
+        return false;
+    }
+    size_type size() const {
+        mockStatus += Size;
+        return contSize;
+    }
+    reference front() {
+        mockStatus += Front;
+        return elemF;
+    }
+    reference back() {
+        mockStatus += Back;
+        return elemB;
+    }
+    void push_back(const_reference elem) {
+        mockStatus += PushBack;
+        contSize++;
+        elemB = elem;
+    }
+    void pop_front() {
+        mockStatus += PopFront;
+        contSize--;
+    }
+    template <typename... Args> void emplace_back(Args &&...args) {
+        mockStatus += Emplace;
+        new (&elemB) uint8_t(std::forward<Args>(args)...);
+    }
+    enum method {
+        Size = 1,
+        Front = 10,
+        Back = 100,
+        PushBack = 1000,
+        PopFront = 10000,
+        Empty = 100000,
+        Emplace = 1000000,
+        MoveConstruct = 10000000,
+        MoveAssign = 100000000
+    };
+
 protected:
     value_type elemF, elemB;
     size_type contSize;
@@ -79,7 +125,7 @@ SCENARIO("Queue") {
         while (fifo.size() > fifo.back())
             fifo.pop();
         REQUIRE(mockStatus == 68807);
-        
+
         fifo.empty();
         REQUIRE(mockStatus == 168807);
 
@@ -88,10 +134,32 @@ SCENARIO("Queue") {
         REQUIRE(mockStatus == 1168907);
 
         Fifo fifo2;
+        mockStatus = 0;
         fifo2.swap(fifo);
+        REQUIRE(mockStatus == SequenceContainerMock::MoveConstruct + 2 * SequenceContainerMock::MoveAssign);
         REQUIRE(fifo2.back() == 150);
         REQUIRE(fifo.back() == 2);
-        REQUIRE(mockStatus == 1169107);
-        
     }
+}
+
+SCENARIO("Queue uses explicit embedded storage") {
+    using EmbeddedFifo = ETLSTD::queue<uint8_t, etl::CircularBuffer<uint8_t, 4>>;
+
+    EmbeddedFifo fifo;
+    fifo.push(1);
+    fifo.push(2);
+    fifo.emplace(3);
+    REQUIRE(fifo.front() == 1);
+    REQUIRE(fifo.back() == 3);
+
+    fifo.pop();
+    REQUIRE(fifo.front() == 2);
+
+    EmbeddedFifo other;
+    other.push(9);
+    fifo.swap(other);
+    REQUIRE(fifo.front() == 9);
+    REQUIRE(fifo.size() == 1);
+    REQUIRE(other.front() == 2);
+    REQUIRE(other.back() == 3);
 }


### PR DESCRIPTION
Resolves the container TODO in `libstd/include/queue`: `queue` stays a thin
adapter over caller-provided storage, rather than growing an internal
`ETLSTD::deque` default. For embedded fixed-capacity FIFOs, use
`etl::CircularBuffer<T,N>` as the `Container` template argument directly.

Also fixes `queue::swap()`, which previously did three full `Container`
copies through a temporary; it now move-swaps via `ETLSTD::swap`.

Adds a test instantiating `queue<uint8_t, etl::CircularBuffer<uint8_t,4>>`
that exercises push/emplace/pop/swap against the real embedded container,
plus updates the existing mock-based test to assert move (not copy)
semantics on swap.

Rebased onto current master (past PR #100, which fixed unrelated AVR
register-naming build failures this branch's CI was blocked on).

Fixes #89