### PR TITLE
Fix string_view boundary and iteration bugs

### DIFF
--- a/libstd/include/exception
+++ b/libstd/include/exception
@@ -35,22 +35,25 @@
 namespace ETLSTD {
 
 class exception {
- public:
-  exception() noexcept {}
-  exception(const exception&) noexcept {}
-  exception& operator=(const exception&) noexcept { return *this;}
-  virtual ~exception() {}
-  virtual const char* what() const noexcept { return nullptr; }
+public:
+    exception() noexcept : what_arg_("") {}
+    explicit exception(const char *what_arg) noexcept : what_arg_(what_arg ? what_arg : "") {}
+    exception(const exception &) noexcept = default;
+    exception &operator=(const exception &) noexcept = default;
+    virtual ~exception() = default;
+    virtual const char *what() const noexcept { return what_arg_; }
+
+protected:
+    const char *what_arg_;
 };
 
 class bad_exception : public exception {
- public:
-  bad_exception() noexcept {}
-  virtual ~bad_exception() noexcept {}
-  virtual const char* what() const noexcept { return nullptr; }
+public:
+    bad_exception() noexcept : exception("bad_exception") {}
+    virtual ~bad_exception() noexcept = default;
 };
 
-using terminate_handler = void(*)();
-using unexpected_handler = void(*)();
+using terminate_handler = void (*)();
+using unexpected_handler = void (*)();
 
 } // namespace ETLSTD

--- a/libstd/include/h/iterator_reverse.h
+++ b/libstd/include/h/iterator_reverse.h
@@ -33,82 +33,110 @@
 #pragma once
 
 namespace ETLSTD {
-  
-template<typename Iterator>
-class reverse_iterator : public iterator< typename iterator_traits<Iterator>::iterator_category,
-                                          typename iterator_traits<Iterator>::value_type,
-                                          typename iterator_traits<Iterator>::difference_type,
-                                          typename iterator_traits<Iterator>::pointer,
-                                          typename iterator_traits<Iterator>::reference > {
- public:
-  using iterator_type   = Iterator;
-  using difference_type = typename iterator_traits<iterator_type>::difference_type;
-  using pointer         = typename iterator_traits<iterator_type>::pointer;
-  using reference       = typename iterator_traits<iterator_type>::reference;
-  
-  /// Constructs a reverse iterator that points to no object.
-  reverse_iterator() : current_() {}
-  
-  /// Constructs a reverse iterator from some original operator it.
-  explicit reverse_iterator(iterator_type it) : current_(it) {}
-  
-  /// Constructs a reverse iterator from some other reverse iterator.
-  template <class Iter>
-  reverse_iterator(const reverse_iterator<Iter>& rev_it) : current_(rev_it.base()) {}
-  
-  /// Returns a copy of the base iterator.  
-  iterator_type base() const { return current_; }
-  
-  /// Returns a reference to the element previous to current.
-  reference operator*() const { Iterator tmp = current_; return *--tmp; }
-  
-  reverse_iterator<Iterator> operator+(difference_type n) const { return reverse_iterator<Iterator>(current_ - n); }
-  reverse_iterator<Iterator> operator-(difference_type n) const { return reverse_iterator<Iterator>(current_ + n); }
-  reverse_iterator<Iterator>& operator+=(difference_type n) const { current_ -= n; return *this; }
-  reverse_iterator<Iterator>& operator-=(difference_type n) const { current_ += n; return *this; }
-  reverse_iterator<Iterator>& operator++() const { --current_; return *this; }
-  reverse_iterator<Iterator>& operator--() const { ++current_; return *this; }
-  reverse_iterator<Iterator>& operator++(int) const { reverse_iterator<Iterator> tmp = *this; --current_; return tmp; }
-  reverse_iterator<Iterator>& operator--(int) const { reverse_iterator<Iterator> tmp = *this; ++current_; return tmp; }
-    
-  pointer operator->() const { return addressof(operator*()); }
-  reference operator[](difference_type n) const { return *(*this + n); }
-      
- protected:
-  Iterator current_;
-};  
+
+template <typename Iterator>
+class reverse_iterator
+    : public iterator<typename iterator_traits<Iterator>::iterator_category, typename iterator_traits<Iterator>::value_type,
+                      typename iterator_traits<Iterator>::difference_type, typename iterator_traits<Iterator>::pointer,
+                      typename iterator_traits<Iterator>::reference> {
+public:
+    using iterator_type = Iterator;
+    using difference_type = typename iterator_traits<iterator_type>::difference_type;
+    using pointer = typename iterator_traits<iterator_type>::pointer;
+    using reference = typename iterator_traits<iterator_type>::reference;
+
+    /// Constructs a reverse iterator that points to no object.
+    reverse_iterator() : current_() {}
+
+    /// Constructs a reverse iterator from some original operator it.
+    explicit reverse_iterator(iterator_type it) : current_(it) {}
+
+    /// Constructs a reverse iterator from some other reverse iterator.
+    template <class Iter> reverse_iterator(const reverse_iterator<Iter> &rev_it) : current_(rev_it.base()) {}
+
+    /// Returns a copy of the base iterator.
+    iterator_type base() const { return current_; }
+
+    /// Returns a reference to the element previous to current.
+    reference operator*() const {
+        Iterator tmp = current_;
+        return *--tmp;
+    }
+
+    reverse_iterator<Iterator> operator+(difference_type n) const { return reverse_iterator<Iterator>(current_ - n); }
+    reverse_iterator<Iterator> operator-(difference_type n) const { return reverse_iterator<Iterator>(current_ + n); }
+    reverse_iterator<Iterator> &operator+=(difference_type n) {
+        current_ -= n;
+        return *this;
+    }
+    reverse_iterator<Iterator> &operator-=(difference_type n) {
+        current_ += n;
+        return *this;
+    }
+    reverse_iterator<Iterator> &operator++() {
+        --current_;
+        return *this;
+    }
+    reverse_iterator<Iterator> &operator--() {
+        ++current_;
+        return *this;
+    }
+    reverse_iterator<Iterator> operator++(int) {
+        reverse_iterator<Iterator> tmp = *this;
+        --current_;
+        return tmp;
+    }
+    reverse_iterator<Iterator> operator--(int) {
+        reverse_iterator<Iterator> tmp = *this;
+        ++current_;
+        return tmp;
+    }
+
+    pointer operator->() const { return addressof(operator*()); }
+    reference operator[](difference_type n) const { return *(*this + n); }
+
+protected:
+    Iterator current_;
+};
 
 // Non member relation operators
-template<typename Iterator1, typename Iterator2>
-bool operator==(const reverse_iterator<Iterator1>& lhs,
-                const reverse_iterator<Iterator2>& rhs) { return lhs.base() == rhs.base(); }  
+template <typename Iterator1, typename Iterator2>
+bool operator==(const reverse_iterator<Iterator1> &lhs, const reverse_iterator<Iterator2> &rhs) {
+    return lhs.base() == rhs.base();
+}
 
-template<typename Iterator1, typename Iterator2>
-bool operator!=(const reverse_iterator<Iterator1>& lhs,
-                const reverse_iterator<Iterator2>& rhs) { return lhs.base() =! rhs.base(); }  
+template <typename Iterator1, typename Iterator2>
+bool operator!=(const reverse_iterator<Iterator1> &lhs, const reverse_iterator<Iterator2> &rhs) {
+    return lhs.base() != rhs.base();
+}
 
-template<typename Iterator1, typename Iterator2>
-bool operator<(const reverse_iterator<Iterator1>& lhs,
-                const reverse_iterator<Iterator2>& rhs) { return lhs.base() > rhs.base(); }  
+template <typename Iterator1, typename Iterator2>
+bool operator<(const reverse_iterator<Iterator1> &lhs, const reverse_iterator<Iterator2> &rhs) {
+    return lhs.base() > rhs.base();
+}
 
-template<typename Iterator1, typename Iterator2>
-bool operator<=(const reverse_iterator<Iterator1>& lhs,
-                const reverse_iterator<Iterator2>& rhs) { return lhs.base() >= rhs.base(); }  
+template <typename Iterator1, typename Iterator2>
+bool operator<=(const reverse_iterator<Iterator1> &lhs, const reverse_iterator<Iterator2> &rhs) {
+    return lhs.base() >= rhs.base();
+}
 
-template<typename Iterator1, typename Iterator2>
-bool operator>(const reverse_iterator<Iterator1>& lhs,
-                const reverse_iterator<Iterator2>& rhs) { return lhs.base() < rhs.base(); }  
+template <typename Iterator1, typename Iterator2>
+bool operator>(const reverse_iterator<Iterator1> &lhs, const reverse_iterator<Iterator2> &rhs) {
+    return lhs.base() < rhs.base();
+}
 
-template<typename Iterator1, typename Iterator2>
-bool operator>=(const reverse_iterator<Iterator1>& lhs,
-                const reverse_iterator<Iterator2>& rhs) { return lhs.base() <= rhs.base(); }  
-                  
+template <typename Iterator1, typename Iterator2>
+bool operator>=(const reverse_iterator<Iterator1> &lhs, const reverse_iterator<Iterator2> &rhs) {
+    return lhs.base() <= rhs.base();
+}
+
 // Specializations
-template<typename T> 
-constexpr const T* rbegin(initializer_list<T> list) noexcept { return reverse_iterator<const T*>(list.end()); }
-  
-template<typename T>
-constexpr const T* rend(initializer_list<T> list) noexcept { return reverse_iterator<const T*>(list.begin()); }
-  
-}; // namespace ETLSTD
+template <typename T> constexpr reverse_iterator<const T *> rbegin(initializer_list<T> list) noexcept {
+    return reverse_iterator<const T *>(list.end());
+}
 
+template <typename T> constexpr reverse_iterator<const T *> rend(initializer_list<T> list) noexcept {
+    return reverse_iterator<const T *>(list.begin());
+}
+
+}; // namespace ETLSTD

--- a/libstd/include/stdexcept
+++ b/libstd/include/stdexcept
@@ -37,69 +37,66 @@
 namespace ETLSTD {
 
 class logic_error : public exception {
- public:
-  logic_error() throw();
-  explicit logic_error(const char* /*what_arg*/) {}
-  virtual ~logic_error() throw() {}
-  virtual const char* what() const throw() { return nullptr; }
-};	
+public:
+    logic_error() throw() : exception("") {}
+    explicit logic_error(const char *what_arg) : exception(what_arg) {}
+    virtual ~logic_error() throw() = default;
+};
 
 class domain_error : public logic_error {
- public:
-  domain_error() : logic_error() {}
-  explicit domain_error(const char* what_arg) : logic_error(what_arg) {}
-  virtual ~domain_error() throw() {}
+public:
+    domain_error() : logic_error() {}
+    explicit domain_error(const char *what_arg) : logic_error(what_arg) {}
+    virtual ~domain_error() throw() {}
 };
 
 class invalid_argument : public logic_error {
- public:
-  invalid_argument() : logic_error() {}
-  explicit invalid_argument(const char* what_arg) : logic_error(what_arg) {}
-  virtual ~invalid_argument() throw() {}
+public:
+    invalid_argument() : logic_error() {}
+    explicit invalid_argument(const char *what_arg) : logic_error(what_arg) {}
+    virtual ~invalid_argument() throw() {}
 };
 
 class length_error : public logic_error {
- public:
-  length_error() : logic_error() {}
-  explicit length_error(const char* what_arg) : logic_error(what_arg){}
-  virtual ~length_error() throw() {}
+public:
+    length_error() : logic_error() {}
+    explicit length_error(const char *what_arg) : logic_error(what_arg) {}
+    virtual ~length_error() throw() {}
 };
 
-class out_of_range : public logic_error{
- public:
-  out_of_range();
-  explicit out_of_range(const char* what_arg);
-  virtual ~out_of_range() throw() {}
+class out_of_range : public logic_error {
+public:
+    out_of_range() : logic_error("") {}
+    explicit out_of_range(const char *what_arg) : logic_error(what_arg) {}
+    virtual ~out_of_range() throw() = default;
 };
 
 class runtime_error : public exception {
- public:
-  runtime_error();
-  explicit runtime_error(const char* /*what_arg*/) {}
-  virtual ~runtime_error() throw() {}
-  virtual const char* what() const throw() { return nullptr; };
+public:
+    runtime_error() : exception("") {}
+    explicit runtime_error(const char *what_arg) : exception(what_arg) {}
+    virtual ~runtime_error() throw() = default;
 };
 
 class range_error : public runtime_error {
- public:
-  range_error() : runtime_error() {}
-  explicit range_error(const char* what_arg) : runtime_error(what_arg) {}
-  virtual ~range_error() throw() {}
+public:
+    range_error() : runtime_error() {}
+    explicit range_error(const char *what_arg) : runtime_error(what_arg) {}
+    virtual ~range_error() throw() {}
 };
 
-
 class overflow_error : public runtime_error {
- public:
-  overflow_error() : runtime_error() {}
-  explicit overflow_error(const char* what_arg) : runtime_error(what_arg) {}
-  virtual ~overflow_error() throw() {}
+public:
+    overflow_error() : runtime_error() {}
+    explicit overflow_error(const char *what_arg) : runtime_error(what_arg) {}
+    virtual ~overflow_error() throw() {}
 };
 
 class underflow_error : public runtime_error {
- public:
-  underflow_error() : runtime_error() {}
-  explicit underflow_error(const char* what_arg) : runtime_error(what_arg) {}
-  virtual ~underflow_error() throw() {}
+public:
+    underflow_error() : runtime_error() {}
+    explicit underflow_error(const char *what_arg) : runtime_error(what_arg) {}
+    virtual ~underflow_error() throw() {}
 };
 
 } // namespace ETLSTD

--- a/libstd/include/string_view
+++ b/libstd/include/string_view
@@ -64,16 +64,20 @@ private:
     const_pointer stringData;
     size_type stringLength;
 
-    constexpr const_pointer storage() const noexcept { return stringData == nullptr ? emptyValue : stringData; }
+    // Only substitute the static empty buffer for truly empty views (length == 0); otherwise
+    // stringData is guaranteed non-null and valid over [0, stringLength) by the constructors below.
+    constexpr const_pointer storage() const noexcept { return stringLength == 0 ? emptyValue : stringData; }
 
 public:
     constexpr basic_string_view() noexcept : stringData(nullptr), stringLength(0) {}
 
     constexpr basic_string_view(const basic_string_view &other) noexcept = default;
 
-    constexpr basic_string_view(const CharT *s, size_t count) : stringData(s), stringLength(count) {}
+    // Normalize a null pointer with a non-zero count to an empty view so that the invariant
+    // "data() is valid over [0, size())" always holds.
+    constexpr basic_string_view(const CharT *s, size_t count) : stringData(s), stringLength(s == nullptr ? 0 : count) {}
 
-    constexpr basic_string_view(const CharT *s) : stringData(s), stringLength(traits_type::length(s)) {}
+    constexpr basic_string_view(const CharT *s) : stringData(s), stringLength(s == nullptr ? 0 : traits_type::length(s)) {}
 
     constexpr const_iterator begin() const noexcept { return storage(); }
 

--- a/libstd/include/string_view
+++ b/libstd/include/string_view
@@ -35,107 +35,87 @@
 #include "h/char_traits.h"
 
 #include <libstd/include/algorithm>
+#include <libstd/include/iterator>
 #include <libstd/include/limits>
 #include <libstd/include/stdexcept>
 
 namespace ETLSTD {
 
-template<typename CharT, typename Traits = char_traits<CharT>>
-class basic_string_view {
+template <typename CharT, typename Traits = char_traits<CharT>> class basic_string_view {
+public:
     using traits_type = Traits;
     using value_type = CharT;
-    using pointer = CharT*;
-    using const_pointer = const CharT*;
-    using reference = CharT&;
-    using const_reference = const CharT&;
-    using const_iterator = const CharT*;
+    using pointer = CharT *;
+    using const_pointer = const CharT *;
+    using reference = CharT &;
+    using const_reference = const CharT &;
+    using const_iterator = const CharT *;
     using iterator = const_iterator;
     using const_reverse_iterator = ETLSTD::reverse_iterator<const_iterator>;
     using reverse_iterator = const_reverse_iterator;
     using size_type = size_t;
     using difference_type = ptrdiff_t;
 
+    static constexpr size_type npos = size_type(-1);
+
+private:
+    inline static constexpr value_type emptyValue[1] = {};
+
     const_pointer stringData;
     size_type stringLength;
+
+    constexpr const_pointer storage() const noexcept { return stringData == nullptr ? emptyValue : stringData; }
+
 public:
     constexpr basic_string_view() noexcept : stringData(nullptr), stringLength(0) {}
 
-    constexpr basic_string_view(const basic_string_view& other) noexcept = default;
+    constexpr basic_string_view(const basic_string_view &other) noexcept = default;
 
-    constexpr basic_string_view(const CharT* s, size_t count) : stringData(s), stringLength(count) {}
+    constexpr basic_string_view(const CharT *s, size_t count) : stringData(s), stringLength(count) {}
 
-    constexpr basic_string_view(const CharT* s) : stringData(s), stringLength(traits_type::length(s)) {}
+    constexpr basic_string_view(const CharT *s) : stringData(s), stringLength(traits_type::length(s)) {}
 
-    constexpr const_iterator begin() const noexcept {
-        return stringData;
-    }
+    constexpr const_iterator begin() const noexcept { return storage(); }
 
-    constexpr const_iterator cbegin() const noexcept {
-        return stringData;
-    }
+    constexpr const_iterator cbegin() const noexcept { return begin(); }
 
-    constexpr const_iterator end() const noexcept {
-        return stringData + stringLength;
-    }
+    constexpr const_iterator end() const noexcept { return begin() + stringLength; }
 
-    constexpr const_iterator cend() const noexcept {
-        return stringData + stringLength;
-    }
+    constexpr const_iterator cend() const noexcept { return end(); }
 
-    constexpr const_reverse_iterator rbegin() const noexcept {
-        if (stringLength == 0)
-            return nullptr;
-        return stringData + stringLength - 1;
-    }
+    constexpr const_reverse_iterator rbegin() const noexcept { return const_reverse_iterator(end()); }
 
-    constexpr const_reverse_iterator crbegin() const noexcept {
-        return rbegin();
-    }
+    constexpr const_reverse_iterator crbegin() const noexcept { return rbegin(); }
 
-    constexpr const_reverse_iterator rend() const noexcept {
-        return stringData - 1;
-    }
+    constexpr const_reverse_iterator rend() const noexcept { return const_reverse_iterator(begin()); }
 
-    constexpr const_reverse_iterator crend() const noexcept {
-        return stringData - 1;
-    }
+    constexpr const_reverse_iterator crend() const noexcept { return rend(); }
 
-    constexpr const_reference operator[](size_type pos) const {
-        return stringData[pos];
-    }
+    constexpr const_reference operator[](size_type pos) const { return data()[pos]; }
 
     constexpr const_reference at(size_type pos) const {
         if (pos >= stringLength) {
             throw out_of_range();
         }
+        return data()[pos];
     }
 
-    constexpr const_reference front() const {
-        return stringData[0];
-    }
+    constexpr const_reference front() const { return data()[0]; }
 
-    constexpr const_reference back() const {
-        return stringData + stringLength - 1;
-    }
+    constexpr const_reference back() const { return data()[stringLength - 1]; }
 
-    constexpr size_type max_size() const noexcept {
-        return etl::Device::flashSize;
-    }
+    constexpr size_type max_size() const noexcept { return etl::Device::flashSize; }
 
-    [[nodiscard]] constexpr bool empty() const noexcept {
-        return stringLength == 0;
-    }
+    [[nodiscard]] constexpr bool empty() const noexcept { return stringLength == 0; }
 
     constexpr void remove_prefix(size_type n) {
-        stringData += n;
+        stringData = data() + n;
         stringLength -= n;
     }
 
-    constexpr void remove_suffix(size_type n) {
-        stringLength -= n;
-    }
+    constexpr void remove_suffix(size_type n) { stringLength -= n; }
 
-    constexpr void swap(basic_string_view& v) noexcept {
+    constexpr void swap(basic_string_view &v) noexcept {
         auto d = v.stringData;
         auto l = v.stringLength;
         v.stringData = stringData;
@@ -144,27 +124,26 @@ public:
         stringLength = l;
     }
 
-    constexpr const_pointer data() const noexcept {
-        return stringData;
-    }
+    constexpr const_pointer data() const noexcept { return storage(); }
 
-    constexpr size_type size() const noexcept {
-        return stringLength;
-    }
+    constexpr size_type size() const noexcept { return stringLength; }
 
-    constexpr size_type llength() const noexcept {
-        return stringLength;
-    }
+    constexpr size_type length() const noexcept { return stringLength; }
 
-    size_type copy(CharT* dest, size_type count, size_type pos = 0) const {
+    constexpr size_type llength() const noexcept { return length(); }
+
+    size_type copy(CharT *dest, size_type count, size_type pos = 0) const {
         if (pos > stringLength)
             throw out_of_range();
         count = min(count, stringLength - pos);
-        copy_n(stringData + pos, count, dest);
+        copy_n(data() + pos, count, dest);
+        return count;
     }
 
-    constexpr basic_string_view substr(size_type pos = 0, size_type count = npos ) const {
-        return basic_string_view(stringData + pos, min(count, stringLength - pos));
+    constexpr basic_string_view substr(size_type pos = 0, size_type count = npos) const {
+        if (pos > stringLength)
+            throw out_of_range();
+        return basic_string_view(data() + pos, min(count, stringLength - pos));
     }
 
     constexpr int compare(basic_string_view v) const noexcept {
@@ -175,7 +154,8 @@ public:
                 return -1;
             if (size() == v.size())
                 return 0;
-            else return 1;
+            else
+                return 1;
         }
         return comp;
     }
@@ -184,20 +164,17 @@ public:
         return substr(pos1, count1).compare(v);
     }
 
-    constexpr int compare(size_type pos1, size_type count1, basic_string_view v,
-                          size_type pos2, size_type count2) const {
+    constexpr int compare(size_type pos1, size_type count1, basic_string_view v, size_type pos2, size_type count2) const {
         return substr(pos1, count1).compare(v.substr(pos2, count2));
     }
 
-    constexpr int compare(const CharT* s) const {
-        return compare(basic_string_view(s));
-    }
+    constexpr int compare(const CharT *s) const { return compare(basic_string_view(s)); }
 
-    constexpr int compare(size_type pos1, size_type count1, const CharT* s) const {
+    constexpr int compare(size_type pos1, size_type count1, const CharT *s) const {
         return substr(pos1, count1).compare(basic_string_view(s));
     }
 
-    constexpr int compare(size_type pos1, size_type count1, const CharT* s, size_type count2) const {
+    constexpr int compare(size_type pos1, size_type count1, const CharT *s, size_type count2) const {
         return substr(pos1, count1).compare(basic_string_view(s, count2));
     }
 
@@ -205,58 +182,60 @@ public:
         return size() >= x.size() && compare(0, x.size(), x) == 0;
     }
 
-    constexpr bool starts_with(CharT x) const noexcept {
-        return starts_with(basic_string_view(&x, 1));
-    }
+    constexpr bool starts_with(CharT x) const noexcept { return starts_with(basic_string_view(&x, 1)); }
 
-    constexpr bool starts_with(const CharT* x) const {
-        return starts_with(basic_string_view(x));
-    }
+    constexpr bool starts_with(const CharT *x) const { return starts_with(basic_string_view(x)); }
 
     constexpr size_type find(basic_string_view v, size_type pos = 0) const noexcept {
+        if (pos > stringLength)
+            return npos;
+        if (v.size() == 0)
+            return pos;
+        if (v.size() > stringLength - pos)
+            return npos;
         for (auto searchIndex = pos; searchIndex <= stringLength - v.size(); ++searchIndex)
-            if (Traits::compare(&stringData[searchIndex], v.data(), v.size()) == 0)
+            if (Traits::compare(data() + searchIndex, v.data(), v.size()) == 0)
                 return searchIndex;
         return npos;
     }
 
-    constexpr size_type find(CharT ch, size_type pos = 0) const noexcept {
-        return find(basic_string_view(&ch, 1), pos);
-    }
+    constexpr size_type find(CharT ch, size_type pos = 0) const noexcept { return find(basic_string_view(&ch, 1), pos); }
 
-    constexpr size_type find(const CharT* s, size_type pos, size_type count) const {
+    constexpr size_type find(const CharT *s, size_type pos, size_type count) const {
         return find(basic_string_view(s, count), pos);
     }
 
-    constexpr size_type find(const CharT* s, size_type pos = 0) const {
-        return find(basic_string_view(s), pos);
-    }
+    constexpr size_type find(const CharT *s, size_type pos = 0) const { return find(basic_string_view(s), pos); }
 
     constexpr size_type rfind(basic_string_view v, size_type pos = npos) const noexcept {
-        if (pos == npos)
-            pos = size() - 1 - v.size();
-        for (auto searchIndex = pos; searchIndex != size_type(-1); --searchIndex)
-            if (Traits::compare(&stringData[searchIndex], v.data(), v.size()) == 0)
+        if (v.size() > stringLength)
+            return npos;
+        if (v.size() == 0)
+            return min(pos, stringLength);
+        auto searchIndex = pos == npos ? stringLength - v.size() : min(pos, stringLength - v.size());
+        for (;; --searchIndex) {
+            if (Traits::compare(data() + searchIndex, v.data(), v.size()) == 0)
                 return searchIndex;
+            if (searchIndex == 0)
+                break;
+        }
         return npos;
     }
 
-    constexpr size_type rfind(CharT c, size_type pos = npos) const noexcept {
-        return rfind(basic_string_view(&c, 1), pos);
-    }
+    constexpr size_type rfind(CharT c, size_type pos = npos) const noexcept { return rfind(basic_string_view(&c, 1), pos); }
 
-    constexpr size_type rfind(const CharT* s, size_type pos, size_type count) const {
+    constexpr size_type rfind(const CharT *s, size_type pos, size_type count) const {
         return rfind(basic_string_view(s, count), pos);
     }
 
-    constexpr size_type rfind(const CharT* s, size_type pos = npos) const {
-        return rfind(basic_string_view(s), pos);
-    }
+    constexpr size_type rfind(const CharT *s, size_type pos = npos) const { return rfind(basic_string_view(s), pos); }
 
     constexpr size_type find_first_of(basic_string_view v, size_type pos = 0) const noexcept {
+        if (pos >= stringLength || v.empty())
+            return npos;
         for (auto searchIndex = pos; searchIndex < stringLength; ++searchIndex)
             for (auto charac : v)
-                if (Traits::eq(stringData[searchIndex], charac))
+                if (Traits::eq(data()[searchIndex], charac))
                     return searchIndex;
         return npos;
     }
@@ -265,21 +244,25 @@ public:
         return find_first_of(basic_string_view(&c, 1), pos);
     }
 
-    constexpr size_type find_first_of(const CharT* s, size_type pos, size_type count) const {
+    constexpr size_type find_first_of(const CharT *s, size_type pos, size_type count) const {
         return find_first_of(basic_string_view(s, count), pos);
     }
 
-    constexpr size_type find_first_of(const CharT* s, size_type pos = 0) const {
+    constexpr size_type find_first_of(const CharT *s, size_type pos = 0) const {
         return find_first_of(basic_string_view(s), pos);
     }
 
     constexpr size_type find_last_of(basic_string_view v, size_type pos = npos) const noexcept {
-        if (pos == npos)
-            pos = size() - 1;
-        for (auto searchIndex = pos; searchIndex != size_type(-1); --searchIndex)
+        if (stringLength == 0 || v.empty())
+            return npos;
+        auto searchIndex = pos == npos ? stringLength - 1 : min(pos, stringLength - 1);
+        for (;; --searchIndex) {
             for (auto charac : v)
-                if (Traits::eq(stringData[searchIndex], charac))
+                if (Traits::eq(data()[searchIndex], charac))
                     return searchIndex;
+            if (searchIndex == 0)
+                break;
+        }
         return npos;
     }
 
@@ -287,19 +270,23 @@ public:
         return find_last_of(basic_string_view(&c, 1), pos);
     }
 
-    constexpr size_type find_last_of(const CharT* s, size_type pos, size_type count) const {
+    constexpr size_type find_last_of(const CharT *s, size_type pos, size_type count) const {
         return find_last_of(basic_string_view(s, count), pos);
     }
 
-    constexpr size_type find_last_of(const CharT* s, size_type pos = npos) const {
+    constexpr size_type find_last_of(const CharT *s, size_type pos = npos) const {
         return find_last_of(basic_string_view(s), pos);
     }
 
     constexpr size_type find_first_not_of(basic_string_view v, size_type pos = 0) const noexcept {
+        if (pos >= stringLength)
+            return npos;
+        if (v.empty())
+            return pos;
         for (auto searchIndex = pos; searchIndex < stringLength; ++searchIndex) {
             bool anyOf = false;
             for (auto c : v)
-                if (Traits::eq(stringData[searchIndex], c))
+                if (Traits::eq(data()[searchIndex], c))
                     anyOf = true;
             if (!anyOf)
                 return searchIndex;
@@ -311,24 +298,29 @@ public:
         return find_first_not_of(basic_string_view(&c, 1), pos);
     }
 
-    constexpr size_type find_first_not_of(const CharT* s, size_type pos, size_type count) const {
+    constexpr size_type find_first_not_of(const CharT *s, size_type pos, size_type count) const {
         return find_first_not_of(basic_string_view(s, count), pos);
     }
 
-    constexpr size_type find_first_not_of(const CharT* s, size_type pos = 0) const {
+    constexpr size_type find_first_not_of(const CharT *s, size_type pos = 0) const {
         return find_first_not_of(basic_string_view(s), pos);
     }
 
     constexpr size_type find_last_not_of(basic_string_view v, size_type pos = npos) const noexcept {
-        if (pos == npos)
-            pos = size() - 1;
-        for (auto searchIndex = pos; searchIndex != size_type(-1); --searchIndex) {
+        if (stringLength == 0)
+            return npos;
+        auto searchIndex = pos == npos ? stringLength - 1 : min(pos, stringLength - 1);
+        if (v.empty())
+            return searchIndex;
+        for (;; --searchIndex) {
             bool anyOf = false;
             for (auto c : v)
-                if (Traits::eq(stringData[searchIndex], c))
+                if (Traits::eq(data()[searchIndex], c))
                     anyOf = true;
             if (!anyOf)
                 return searchIndex;
+            if (searchIndex == 0)
+                break;
         }
         return npos;
     }
@@ -337,50 +329,42 @@ public:
         return find_last_not_of(basic_string_view(&c, 1), pos);
     }
 
-    constexpr size_type find_last_not_of(const CharT* s, size_type pos, size_type count) const {
+    constexpr size_type find_last_not_of(const CharT *s, size_type pos, size_type count) const {
         return find_last_not_of(basic_string_view(s, count), pos);
     }
 
-    constexpr size_type find_last_not_of(const CharT* s, size_type pos = npos) const {
+    constexpr size_type find_last_not_of(const CharT *s, size_type pos = npos) const {
         return find_last_not_of(basic_string_view(s), pos);
     }
-
-    static constexpr size_type npos = size_type(-1);
 };
 
-template<typename CharT, typename Traits>
-constexpr bool operator==( basic_string_view<CharT,Traits> lhs,
-                           basic_string_view<CharT,Traits> rhs ) noexcept {
+template <typename CharT, typename Traits>
+constexpr bool operator==(basic_string_view<CharT, Traits> lhs, basic_string_view<CharT, Traits> rhs) noexcept {
     return lhs.compare(rhs) == 0;
 }
 
-template<typename CharT, typename Traits>
-constexpr bool operator!=( basic_string_view<CharT,Traits> lhs,
-                           basic_string_view<CharT,Traits> rhs ) noexcept {
+template <typename CharT, typename Traits>
+constexpr bool operator!=(basic_string_view<CharT, Traits> lhs, basic_string_view<CharT, Traits> rhs) noexcept {
     return lhs.compare(rhs) != 0;
 }
 
-template<typename CharT, typename Traits>
-constexpr bool operator<( basic_string_view<CharT,Traits> lhs,
-                          basic_string_view<CharT,Traits> rhs ) noexcept {
+template <typename CharT, typename Traits>
+constexpr bool operator<(basic_string_view<CharT, Traits> lhs, basic_string_view<CharT, Traits> rhs) noexcept {
     return lhs.compare(rhs) < 0;
 }
 
-template<typename CharT, typename Traits>
-constexpr bool operator<=( basic_string_view<CharT,Traits> lhs,
-                           basic_string_view<CharT,Traits> rhs ) noexcept {
+template <typename CharT, typename Traits>
+constexpr bool operator<=(basic_string_view<CharT, Traits> lhs, basic_string_view<CharT, Traits> rhs) noexcept {
     return lhs.compare(rhs) <= 0;
 }
 
-template<typename CharT, typename Traits>
-constexpr bool operator>( basic_string_view<CharT,Traits> lhs,
-                          basic_string_view<CharT,Traits> rhs ) noexcept {
-    return lhs.compare(rhs) >  0;
+template <typename CharT, typename Traits>
+constexpr bool operator>(basic_string_view<CharT, Traits> lhs, basic_string_view<CharT, Traits> rhs) noexcept {
+    return lhs.compare(rhs) > 0;
 }
 
-template<typename CharT, typename Traits>
-constexpr bool operator>=( basic_string_view<CharT,Traits> lhs,
-                           basic_string_view<CharT,Traits> rhs ) noexcept {
+template <typename CharT, typename Traits>
+constexpr bool operator>=(basic_string_view<CharT, Traits> lhs, basic_string_view<CharT, Traits> rhs) noexcept {
     return lhs.compare(rhs) >= 0;
 }
 
@@ -389,21 +373,12 @@ using wstring_view = basic_string_view<wchar_t>;
 using u16string_view = basic_string_view<char16_t>;
 using u32string_view = basic_string_view<char32_t>;
 
+constexpr string_view operator"" sv(const char *str, size_t len) noexcept { return string_view{str, len}; }
 
-constexpr string_view operator "" sv(const char* str, size_t len) noexcept {
-    return string_view{str, len};
-}
+constexpr u16string_view operator"" sv(const char16_t *str, size_t len) noexcept { return u16string_view{str, len}; }
 
-constexpr u16string_view operator "" sv(const char16_t* str, size_t len) noexcept {
-    return u16string_view{str, len};
-}
+constexpr u32string_view operator"" sv(const char32_t *str, size_t len) noexcept { return u32string_view{str, len}; }
 
-constexpr u32string_view operator "" sv(const char32_t* str, size_t len) noexcept {
-    return u32string_view{str, len};
-}
-
-constexpr wstring_view   operator "" sv(const wchar_t* str, size_t len) noexcept {
-    return wstring_view{str, len};
-}
+constexpr wstring_view operator"" sv(const wchar_t *str, size_t len) noexcept { return wstring_view{str, len}; }
 
 } // namespace ETLSTD

--- a/test/libstd/string_view.cpp
+++ b/test/libstd/string_view.cpp
@@ -40,9 +40,11 @@
 using namespace ETLSTD;
 
 SCENARIO("Test of std::string_view") {
-    const char* str = "std::string_view";
+    const char *str = "std::string_view";
     string_view v = str;
     REQUIRE(v.size() == 16);
+    REQUIRE(v.length() == 16);
+    REQUIRE(v.llength() == 16);
     for (size_t index = 0; index < v.size(); ++index)
         REQUIRE(v[index] == str[index]);
     REQUIRE(v.compare("std::string_view") == 0);
@@ -52,7 +54,75 @@ SCENARIO("Test of std::string_view") {
 
     string_view v2("std::string");
     REQUIRE(v.starts_with(v2));
+}
 
+SCENARIO("std::string_view element access and copy") {
+    string_view v("string_view");
+
+    REQUIRE(v.at(0) == 's');
+    REQUIRE(v.at(v.size() - 1) == 'w');
+    REQUIRE_THROWS_AS(v.at(v.size()), out_of_range);
+    REQUIRE(v.back() == 'w');
+
+    char copied[8] = {};
+    REQUIRE(v.copy(copied, 6) == 6);
+    REQUIRE(string_view(copied, 6) == "string"sv);
+    REQUIRE(v.copy(copied, sizeof(copied), 7) == 4);
+    REQUIRE(string_view(copied, 4) == "view"sv);
+    REQUIRE_THROWS_AS(v.copy(copied, sizeof(copied), v.size() + 1), out_of_range);
+
+    REQUIRE(v.substr(7) == "view"sv);
+    REQUIRE_THROWS_AS(v.substr(v.size() + 1), out_of_range);
+}
+
+SCENARIO("std::string_view reverse iteration") {
+    string_view v("abc");
+    char reversed[4] = {};
+    size_t index = 0;
+
+    for (auto it = v.rbegin(); it != v.rend(); ++it)
+        reversed[index++] = *it;
+
+    REQUIRE(index == 3);
+    REQUIRE(string_view(reversed, 3) == "cba"sv);
+    REQUIRE(*v.rbegin() == 'c');
+
+    string_view empty;
+    REQUIRE(empty.rbegin() == empty.rend());
+    REQUIRE(empty.crbegin() == empty.crend());
+}
+
+SCENARIO("std::string_view empty boundary behavior") {
+    string_view empty;
+    REQUIRE(empty.empty());
+    REQUIRE(empty.size() == 0);
+    REQUIRE(empty.begin() == empty.end());
+    REQUIRE(empty.cbegin() == empty.cend());
+    REQUIRE_THROWS_AS(empty.at(0), out_of_range);
+    REQUIRE(empty.substr(0).empty());
+    REQUIRE_THROWS_AS(empty.substr(1), out_of_range);
+
+    char untouched[2] = {'x', 'y'};
+    REQUIRE(empty.copy(untouched, 2) == 0);
+    REQUIRE(untouched[0] == 'x');
+    REQUIRE(untouched[1] == 'y');
+
+    REQUIRE(empty.find(""sv) == 0);
+    REQUIRE(empty.rfind(""sv) == 0);
+    REQUIRE(empty.find('x') == string_view::npos);
+    REQUIRE(empty.find("x") == string_view::npos);
+    REQUIRE(empty.find_first_of("x") == string_view::npos);
+    REQUIRE(empty.find_last_of("x") == string_view::npos);
+    REQUIRE(empty.find_first_not_of("") == string_view::npos);
+    REQUIRE(empty.find_last_not_of("") == string_view::npos);
+
+    string_view v("abc");
+    REQUIRE(v.find(""sv, v.size()) == v.size());
+    REQUIRE(v.find(""sv, v.size() + 1) == string_view::npos);
+    REQUIRE(v.rfind(""sv) == v.size());
+    REQUIRE(v.rfind("bc"sv, 99) == 1);
+    REQUIRE(v.find_first_not_of("") == 0);
+    REQUIRE(v.find_last_not_of("") == v.size() - 1);
 }
 
 SCENARIO("std::string_view find functions") {
@@ -70,7 +140,6 @@ SCENARIO("std::string_view find functions") {
     string_view v2("string with four words.");
     REQUIRE(v.find(v2.substr(7, 4)) == 16);
 }
-
 
 SCENARIO("std::string_view rfind functions") {
     string_view v("String with multiple 'with' words within.");
@@ -122,11 +191,10 @@ SCENARIO("std::string_view find_last_not_of functions") {
 }
 
 SCENARIO("std::string_view comparisons") {
-    auto s1 { "String1"sv };
+    auto s1{"String1"sv};
     auto s2 = "String2"sv;
     string_view s3("String1 longer");
     string_view s4("String1");
-
 
     REQUIRE(s1 == s4);
     REQUIRE(s2 > s1);
@@ -137,7 +205,6 @@ SCENARIO("std::string_view comparisons") {
     REQUIRE(s1 <= s2);
     REQUIRE(s1 <= s4);
 }
-
 
 SCENARIO("std::string trim functions") {
     const char *str = "   trim me";


### PR DESCRIPTION
Ports #86's fix onto current master (the original branch forked before
the AVR register-naming fix in d1162b6/#100, so its CI was red for
unrelated reasons).

- `at()` now returns after its bounds check instead of falling through.
- `back()` dereferences instead of returning a pointer.
- `copy()` returns the copied character count.
- `rbegin()/rend()` return `const_reverse_iterator` instead of raw pointers.
- Type aliases (`traits_type`, `value_type`, ...) are `public` again.
- `find`/`rfind`/`find_first_of`/`find_last_of`/`find_first_not_of`/`find_last_not_of`
  correctly handle empty needles and out-of-range `pos`.
- `data()`/`begin()` fall back to a static empty buffer so an empty/null view
  never dereferences null.
- `reverse_iterator`'s mutating operators are no longer `const`-qualified
  (they couldn't mutate `current_` before), and `operator!=` had a `=!` typo.
- Pulled in the exception/stdexcept constructor fix (matching #97's more
  complete version) since `at()`/`copy()`/`substr()` now actually throw
  `out_of_range`, which previously had declared-but-undefined constructors
  and would fail to link.

Expanded `test/libstd/string_view.cpp` to cover element access, copy,
reverse iteration, and empty/boundary behavior.

Build + `ctest` pass with zero regressions.

Fixes #86