### PR TITLE
Harden functional invoke/reference_wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,9 @@ set(LIBSTD_HEADERS  libstd/include/algorithm libstd/include/array libstd/include
         libstd/include/iterator libstd/include/limits libstd/include/memory libstd/include/new libstd/include/queue libstd/include/random
         libstd/include/ratio libstd/include/stdexcept libstd/include/string libstd/include/thread libstd/include/tuple
         libstd/include/type_traits libstd/include/utility libstd/include/vector)
-set(LIBSTD_TESTS test/libstd/bitset.cpp test/libstd/chrono.cpp test/libstd/limits.cpp test/libstd/memory.cpp test/libstd/tuple.cpp test/libstd/type_traits.cpp
-                 test/libstd/queue.cpp test/libstd/string.cpp test/libstd/string_view.cpp test/libstd/vector.cpp)
+set(LIBSTD_TESTS test/libstd/bitset.cpp test/libstd/chrono.cpp test/libstd/functional.cpp test/libstd/limits.cpp test/libstd/memory.cpp
+                 test/libstd/tuple.cpp test/libstd/type_traits.cpp test/libstd/queue.cpp test/libstd/string.cpp test/libstd/string_view.cpp
+                 test/libstd/vector.cpp)
                  
 set(ETL_TESTS test/test.cpp test/SetClearTest.cpp test/InterruptsTest.cpp test/CircularBuffer.cpp)
 set(ETL_ARCHITECTURE include/etl/architecture/MockCore.h)

--- a/libstd/include/functional
+++ b/libstd/include/functional
@@ -33,48 +33,4 @@
 #pragma once
 #include "h/functional.h"
 #include "h/functional_operators.h"
-#include <libstd/include/type_traits>
-#include <libstd/include/memory>
-
-namespace ETLSTD {
-
-
-template<typename T>
-class reference_wrapper {
-public:
-    using type = T;
-
-    /// Constructor : stores a reference to x.
-    reference_wrapper(T& x) noexcept : data(addressof(x)) {}
-
-    /// Move constructor : deleted, construction from a temporary object is not allowed.
-    reference_wrapper(T&&) = delete;
-
-    /// Copy constructor : stores a reference to other.get().
-    reference_wrapper(const reference_wrapper<T>& other) noexcept : data(addressof(other.get())) {}
-
-    operator T& () const noexcept { return *data; }
-    T& get() const noexcept { return *data; }
-    
-    template<typename... Args> typename result_of<T&(Args&&...) >::type operator() (Args&&... args) const {
-        return invoke(get(), forward<Args>(args)...);
-    }
-private:
-    T* data;
-};
-
-template<typename T> reference_wrapper<T> ref(T& t) { return reference_wrapper<T>(t); }
-template<typename T> reference_wrapper<T> ref(reference_wrapper<T> t) { return ref(t.get()); }
-template<typename T> void ref(const T&&) = delete;
-template<typename T> reference_wrapper<const T> cref(const T& t) { return reference_wrapper<const T>(t); }
-template<typename T> reference_wrapper<const T> cref(reference_wrapper<T> t) { return cref(t.get()); }
-template<typename T> void cref(const T&&) = delete;
-
-namespace etlHelper {
-    template<typename T> struct is_reference_wrapper : false_type {};
-    template<typename U> struct is_reference_wrapper<reference_wrapper<U>> : true_type {};
-    template<typename T> using is_reference_wrapper_v = typename is_reference_wrapper<T>::value;
-} // namespace etlHelper
-
-} // namespace ETLSTD
-
+#include "h/functional_reference_wrapper.h"

--- a/libstd/include/h/functional.h
+++ b/libstd/include/h/functional.h
@@ -31,93 +31,83 @@
 //  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 //  POSSIBILITY OF SUCH DAMAGE.
 #pragma once
+
 #include <libstd/include/type_traits>
 #include <libstd/include/utility>
 
 namespace ETLSTD {
 
-namespace etlHelper { /*
-	template<typename Base, typename T, typename Derived, typename... Args>
-	auto invoke(T Base::*pmf, Derived&& ref, Args&&... args) noexcept(noexcept((std::forward<Derived>(ref).*pmf)(std::forward<Args>(args)...)))
-	-> std::enable_if_t<std::is_function_v<T> && std::is_base_of_v<Base, std::decay_t<Derived>>, decltype((std::forward<Derived>(ref).*pmf)(std::forward<Args>(args)...))> {
-		return (std::forward<Derived>(ref).*pmf)(std::forward<Args>(args)...);
-	}
-	
-	template<typename Base, typename T, typename RefWrap, typename... Args>
-	auto invoke(T Base::*pmf, RefWrap&& ref, Args&&... args) noexcept(noexcept((ref.get().*pmf)(std::forward<Args>(args)...)))
-	-> std::enable_if_t<std::is_function_v<T> && is_reference_wrapper_v<std::decay_t<RefWrap>>, decltype((ref.get().*pmf)(std::forward<Args>(args)...))> {
-		return (ref.get().*pmf)(std::forward<Args>(args)...);
-	}
-	
-	template<typename Base, typename T, typename Pointer, typename... Args>
-	auto invoke(T Base::*pmf, Pointer&& ptr, Args&&... args) noexcept(noexcept(((*std::forward<Pointer>(ptr)).*pmf)(std::forward<Args>(args)...)))
-	-> std::enable_if_t<std::is_function_v<T> && !is_reference_wrapper_v<std::decay_t<Pointer>> && !std::is_base_of_v<Base, std::decay_t<Pointer>>, decltype(((*std::forward<Pointer>(ptr)).*pmf)(std::forward<Args>(args)...))> {
-		return ((*std::forward<Pointer>(ptr)).*pmf)(std::forward<Args>(args)...);
-	}
-	
-	template<typename Base, typename T, typename Derived>
-	auto invoke(T Base::*pmd, Derived&& ref) noexcept(noexcept(std::forward<Derived>(ref).*pmd))
-	-> std::enable_if_t<!std::is_function_v<T> && std::is_base_of_v<Base, std::decay_t<Derived>>, decltype(std::forward<Derived>(ref).*pmd)> {
-		return std::forward<Derived>(ref).*pmd;
-	}
-	
-	template<typename Base, typename T, typename RefWrap>
-	auto invoke(T Base::*pmd, RefWrap&& ref) noexcept(noexcept(ref.get().*pmd))
-	-> std::enable_if_t<!std::is_function_v<T> && is_reference_wrapper_v<std::decay_t<RefWrap>>, decltype(ref.get().*pmd)> {
-		return ref.get().*pmd;
-	}
-	
-	template<typename Base, typename T, typename Pointer>
-	auto invoke(T Base::*pmd, Pointer&& ptr) noexcept(noexcept((*std::forward<Pointer>(ptr)).*pmd))
-	-> std::enable_if_t<!std::is_function_v<T> && !is_reference_wrapper_v<std::decay_t<Pointer>> && !std::is_base_of_v<Base, std::decay_t<Pointer>>, decltype((*std::forward<Pointer>(ptr)).*pmd)> {
-		return (*std::forward<Pointer>(ptr)).*pmd;
-	}
-	
-	template<typename F, typename... Args>
-	auto invoke(F&& f, Args&&... args) noexcept(noexcept(std::forward<F>(f)(std::forward<Args>(args)...)))
-	-> std::enable_if_t<!std::is_member_pointer_v<std::decay_t<F>>, decltype(std::forward<F>(f)(std::forward<Args>(args)...))> {
-		return std::forward<F>(f)(std::forward<Args>(args)...);
-	}
-	*/
-	template <class F, class... Args> inline auto invoke(F&& f, Args&&... args) -> decltype(forward<F>(f)(forward<Args>(args)...)) {
-		return forward<F>(f)(forward<Args>(args)...);
-	}
-	
-	template <class Base, class T, class Derived> inline auto invoke(T Base::*pmd, Derived&& ref) -> decltype(forward<Derived>(ref).*pmd) {
-		return forward<Derived>(ref).*pmd;
-	}
-	
-	template <class PMD, class Pointer> inline auto invoke(PMD&& pmd, Pointer&& ptr) ->	decltype((*forward<Pointer>(ptr)).*forward<PMD>(pmd)) {
-		return (*forward<Pointer>(ptr)).*forward<PMD>(pmd);
-	}
-	
-	template <class Base, class T, class Derived, class... Args> inline auto invoke(T Base::*pmf, Derived&& ref, Args&&... args) ->	decltype((forward<Derived>(ref).*pmf)(forward<Args>(args)...)) {
-		return (forward<Derived>(ref).*pmf)(forward<Args>(args)...);
-	}
-	
-	template <class PMF, class Pointer, class... Args> inline auto INVOKE(PMF&& pmf, Pointer&& ptr, Args&&... args) -> decltype(((*forward<Pointer>(ptr)).*forward<PMF>(pmf))(forward<Args>(args)...)) {
-		return ((*forward<Pointer>(ptr)).*forward<PMF>(pmf))(forward<Args>(args)...);
-	}
+template <typename T> class reference_wrapper;
 
-	template<typename, typename = void> struct result_of {};
-	template<typename F, typename...Args> struct result_of<F(Args...), decltype(void(invoke(declval<F>(), declval<Args>()...)))> {
-		using type = decltype(invoke(declval<F>(), declval<Args>()...));
+namespace etlHelper {
+
+template <typename T> struct is_reference_wrapper : false_type {};
+
+template <typename T> struct is_reference_wrapper<reference_wrapper<T>> : true_type {};
+
+template <typename T> inline constexpr bool is_reference_wrapper_v = is_reference_wrapper<T>::value;
+
+template <typename T> constexpr T &&unwrap_reference(T &&value) noexcept { return forward<T>(value); }
+
+template <typename T> constexpr T &unwrap_reference(reference_wrapper<T> value) noexcept { return value.get(); }
+
+template <typename MemPtr, typename Obj>
+constexpr auto invoke_member_object(MemPtr &&mem_ptr, Obj &&obj) -> decltype(unwrap_reference(forward<Obj>(obj)).*mem_ptr) {
+    return unwrap_reference(forward<Obj>(obj)).*mem_ptr;
+}
+
+template <typename MemPtr, typename Ptr>
+constexpr auto invoke_member_object(MemPtr &&mem_ptr, Ptr &&ptr) -> decltype((*forward<Ptr>(ptr)).*mem_ptr) {
+    return (*forward<Ptr>(ptr)).*mem_ptr;
+}
+
+template <typename MemFn, typename Obj, typename... Args>
+constexpr auto invoke_member_function(MemFn &&mem_fn, Obj &&obj, Args &&...args)
+    -> decltype((unwrap_reference(forward<Obj>(obj)).*mem_fn)(forward<Args>(args)...)) {
+    return (unwrap_reference(forward<Obj>(obj)).*mem_fn)(forward<Args>(args)...);
+}
+
+template <typename MemFn, typename Ptr, typename... Args>
+constexpr auto invoke_member_function(MemFn &&mem_fn, Ptr &&ptr, Args &&...args)
+    -> decltype(((*forward<Ptr>(ptr)).*mem_fn)(forward<Args>(args)...)) {
+    return ((*forward<Ptr>(ptr)).*mem_fn)(forward<Args>(args)...);
+}
+
+template <typename F, typename... Args, enable_if_t<!is_member_pointer<decay_t<F>>::value, int> = 0>
+constexpr auto invoke(F &&f, Args &&...args) -> decltype(forward<F>(f)(forward<Args>(args)...)) {
+    return forward<F>(f)(forward<Args>(args)...);
+}
+
+template <typename MemPtr, typename Obj, typename... Args,
+          enable_if_t<is_member_function_pointer<decay_t<MemPtr>>::value, int> = 0>
+constexpr auto invoke(MemPtr &&mem_ptr, Obj &&obj, Args &&...args)
+    -> decltype(invoke_member_function(forward<MemPtr>(mem_ptr), forward<Obj>(obj), forward<Args>(args)...)) {
+    return invoke_member_function(forward<MemPtr>(mem_ptr), forward<Obj>(obj), forward<Args>(args)...);
+}
+
+template <typename MemPtr, typename Obj, enable_if_t<is_member_object_pointer<decay_t<MemPtr>>::value, int> = 0>
+constexpr auto invoke(MemPtr &&mem_ptr, Obj &&obj)
+    -> decltype(invoke_member_object(forward<MemPtr>(mem_ptr), forward<Obj>(obj))) {
+    return invoke_member_object(forward<MemPtr>(mem_ptr), forward<Obj>(obj));
+}
+
+template <typename, typename = void> struct result_of {};
+
+template <typename F, typename... Args> struct result_of<F(Args...), decltype(void(invoke(declval<F>(), declval<Args>()...)))> {
+    using type = decltype(invoke(declval<F>(), declval<Args>()...));
 };
+
 } // namespace etlHelper
 
-    
-/// Invoke the Callable object f with the parameters args.
-/// @param[in] f Callable to be invoked
-/// @param[in] args arguments to pass to f
 template <typename F, typename... ArgTypes>
-auto invoke(F&& f, ArgTypes&&... args) noexcept(noexcept(etlHelper::invoke(forward<F>(f), forward<ArgTypes>(args)...))) {
+constexpr auto invoke(F &&f,
+                      ArgTypes &&...args) noexcept(noexcept(etlHelper::invoke(forward<F>(f), forward<ArgTypes>(args)...)))
+    -> decltype(etlHelper::invoke(forward<F>(f), forward<ArgTypes>(args)...)) {
     return etlHelper::invoke(forward<F>(f), forward<ArgTypes>(args)...);
 }
 
-/// Deduces the return type of a function call expression at compile time.    
-template<typename F> struct result_of {};
-template<typename F, typename... ArgTypes> struct result_of<F(ArgTypes...)> : etlHelper::result_of<F(ArgTypes...)> {};
+template <typename F> struct result_of {};
 
+template <typename F, typename... ArgTypes> struct result_of<F(ArgTypes...)> : etlHelper::result_of<F(ArgTypes...)> {};
 
-} // namespace ETLSTD  
-
+} // namespace ETLSTD

--- a/libstd/include/h/functional_reference_wrapper.h
+++ b/libstd/include/h/functional_reference_wrapper.h
@@ -1,7 +1,7 @@
-/// @file functional.h
-/// @data 06/06/2014 18:36:55
+/// @file functional_reference_wrapper.h
+/// @date 06/06/2014 18:36:55
 /// @author Ambroise Leclerc
-/// @brief reference_wrapper : wraps a reference in an assignable and copyable object..
+/// @brief reference_wrapper : wraps a reference in an assignable and copyable object.
 //
 // Copyright (c) 2014, Ambroise Leclerc
 //   All rights reserved.
@@ -32,30 +32,60 @@
 //  POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <libstd/include/type_traits>
-#include <libstd/include/memory>
+#include <libstd/include/h/functional.h>
 
 namespace ETLSTD {
 
-template<typename T>
-class reference_wrapper /*: public etlHelper::reference_wrapper_base<typename std::remove_cv<T>::type> */{
- public:
-  using type = T;
-  
-  /// Constructor : stores a reference to x.
-  reference_wrapper(T& x) noexcept : data_(std::addressof(x)) {}
-  
-  /// Move constructor : deleted, construction from a temporary object is not allowed.
-  reference_wrapper(T&&) = delete;
-  
-  /// Copy constructor : stores a reference to other.get().
-  reference_wrapper(const std::reference_wrapper<T>& other) noexcept : data_(std::addressof(other.get())) {}
- private:
-  T* data_;  
-};  
-  
-  
-} // namespace ETLSTD  
+namespace etlHelper {
 
+template <typename T> constexpr T *reference_wrapper_addressof(T &value) noexcept {
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_addressof(value);
+#else
+    return &value;
+#endif
+}
 
-#endif // ETL_LIBSTD_FUNCTIONAL_REFERENCE_WRAPPER_H_
+} // namespace etlHelper
+
+template <typename T> class reference_wrapper {
+public:
+    using type = T;
+
+    constexpr reference_wrapper(T &value) noexcept : data_(etlHelper::reference_wrapper_addressof(value)) {}
+    reference_wrapper(T &&) = delete;
+    constexpr reference_wrapper(const reference_wrapper &) noexcept = default;
+    constexpr reference_wrapper &operator=(const reference_wrapper &) noexcept = default;
+
+    constexpr operator T &() const noexcept { return *data_; }
+    constexpr T &get() const noexcept { return *data_; }
+
+    template <typename... Args>
+    constexpr auto operator()(Args &&...args) const noexcept(noexcept(ETLSTD::invoke(get(), forward<Args>(args)...)))
+        -> decltype(ETLSTD::invoke(get(), forward<Args>(args)...)) {
+        return ETLSTD::invoke(get(), forward<Args>(args)...);
+    }
+
+private:
+    T *data_;
+};
+
+template <typename T> constexpr reference_wrapper<T> ref(T &value) noexcept { return reference_wrapper<T>(value); }
+
+template <typename T> constexpr reference_wrapper<T> ref(reference_wrapper<T> value) noexcept {
+    return reference_wrapper<T>(value.get());
+}
+
+template <typename T> void ref(const T &&) = delete;
+
+template <typename T> constexpr reference_wrapper<const T> cref(const T &value) noexcept {
+    return reference_wrapper<const T>(value);
+}
+
+template <typename T> constexpr reference_wrapper<const T> cref(reference_wrapper<T> value) noexcept {
+    return cref(value.get());
+}
+
+template <typename T> void cref(const T &&) = delete;
+
+} // namespace ETLSTD

--- a/test/libstd/functional.cpp
+++ b/test/libstd/functional.cpp
@@ -1,0 +1,100 @@
+/// @file test/libstd/functional.cpp
+/// @date 01/07/2026
+/// @author Ambroise Leclerc
+/// @brief BDD tests for <functional>
+//
+// Copyright (c) 2026, Ambroise Leclerc
+//   All rights reserved.
+//
+//   Redistribution and use in source and binary forms, with or without
+//   modification, are permitted provided that the following conditions are met:
+//
+//   * Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in
+//     the documentation and/or other materials provided with the
+//     distribution.
+//   * Neither the name of the copyright holders nor the names of
+//     contributors may be used to endorse or promote products derived
+//     from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+
+#include <catch.hpp>
+
+#define __Mock_Mock__
+#define ETLSTD etlstd
+#include <libstd/include/functional>
+
+using namespace ETLSTD;
+
+namespace {
+
+int add_pair(int lhs, int rhs) { return lhs + rhs; }
+
+struct Accumulator {
+    int bias = 0;
+
+    int add(int value) {
+        bias += value;
+        return bias;
+    }
+
+    int add_const(int value) const { return bias + value; }
+};
+
+struct Callable {
+    int operator()(int lhs, int rhs) const { return lhs * 10 + rhs; }
+};
+
+static_assert(is_same<decltype(invoke(add_pair, 1, 2)), int>::value, "");
+static_assert(is_same<decltype(invoke(&Accumulator::add, declval<Accumulator &>(), 1)), int>::value, "");
+static_assert(is_same<decltype(invoke(&Accumulator::bias, declval<Accumulator &>())), int &>::value, "");
+
+} // namespace
+
+SCENARIO("std::invoke supports direct callables", "[functional]") {
+    REQUIRE(invoke(add_pair, 2, 5) == 7);
+    REQUIRE(invoke(Callable{}, 3, 4) == 34);
+
+    Callable callable;
+    auto wrapped = ref(callable);
+    REQUIRE(invoke(wrapped, 4, 2) == 42);
+    REQUIRE(wrapped(1, 9) == 19);
+}
+
+SCENARIO("std::invoke supports member pointers", "[functional]") {
+    Accumulator accumulator{3};
+
+    REQUIRE(invoke(&Accumulator::bias, accumulator) == 3);
+    REQUIRE(invoke(&Accumulator::bias, &accumulator) == 3);
+    REQUIRE(invoke(&Accumulator::bias, ref(accumulator)) == 3);
+
+    REQUIRE(invoke(&Accumulator::add, accumulator, 4) == 7);
+    REQUIRE(invoke(&Accumulator::add, &accumulator, 5) == 12);
+    REQUIRE(invoke(&Accumulator::add, ref(accumulator), 6) == 18);
+    REQUIRE(invoke(&Accumulator::add_const, cref(accumulator), 2) == 20);
+}
+
+SCENARIO("std::reference_wrapper keeps referenced storage", "[functional]") {
+    int value = 4;
+
+    auto wrapped = ref(value);
+    wrapped.get() = 9;
+    REQUIRE(value == 9);
+
+    const int constant = 12;
+    auto const_wrapped = cref(constant);
+    REQUIRE(const_wrapped.get() == 12);
+}


### PR DESCRIPTION
## Summary
- `reference_wrapper` was defined twice: inline in `libstd/include/functional`, and again in the never-included `libstd/include/h/functional_reference_wrapper.h` (which ended in an orphaned `#endif` with no matching `#ifndef`/`#define`). Consolidated to a single definition in `functional_reference_wrapper.h`, now actually included from `<functional>`, using a local `addressof` helper instead of hardcoded `std::addressof`.
- Rewrote `invoke()` in `functional.h` with SFINAE-dispatched overloads for plain callables, member-function pointers, and member-object pointers, replacing the previous single overload (which couldn't call member pointers) and the dead commented-out implementation left in the header.
- Added `test/libstd/functional.cpp`, registered in `LIBSTD_TESTS`.

Rebased onto current master (which contains the AVR ioports fix from #100); original branch was forked before that fix and had an unrelated red CI.

## Test plan
- [x] `cmake -S . -B build && cmake --build build -j$(nproc)`
- [x] `ctest --test-dir build --output-on-failure` — all tests pass

Fixes #95