### PR TITLE
Fix libstd array API correctness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(LIBSTD_HEADERS  libstd/include/algorithm libstd/include/array libstd/include
         libstd/include/iterator libstd/include/limits libstd/include/memory libstd/include/new libstd/include/queue libstd/include/random
         libstd/include/ratio libstd/include/stdexcept libstd/include/string libstd/include/thread libstd/include/tuple
         libstd/include/type_traits libstd/include/utility libstd/include/vector)
-set(LIBSTD_TESTS test/libstd/bitset.cpp test/libstd/chrono.cpp test/libstd/limits.cpp test/libstd/memory.cpp test/libstd/tuple.cpp test/libstd/type_traits.cpp
+set(LIBSTD_TESTS test/libstd/array.cpp test/libstd/bitset.cpp test/libstd/chrono.cpp test/libstd/limits.cpp test/libstd/memory.cpp test/libstd/tuple.cpp test/libstd/type_traits.cpp
                  test/libstd/queue.cpp test/libstd/string.cpp test/libstd/string_view.cpp test/libstd/vector.cpp)
                  
 set(ETL_TESTS test/test.cpp test/SetClearTest.cpp test/InterruptsTest.cpp test/CircularBuffer.cpp)

--- a/libstd/include/array
+++ b/libstd/include/array
@@ -32,174 +32,181 @@
 //  POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
-#include <libstd/include/iterator>
 #include <libstd/include/algorithm>
+#include <libstd/include/iterator>
 #include <libstd/include/stdexcept>
 
 namespace ETLSTD {
 
-template<typename T, size_t N>
-struct array {
-    using value_type        = T;
-    using pointer           = T*;
-    using const_pointer     = const T;
-    using reference         = T&;
-    using const_reference   = const T&;
-    using iterator          = T*;
-    using const_iterator    = const T*;
-    using size_type         = size_t;
-    using difference_type   = ptrdiff_t;
-    using reverse_iterator  = ETLSTD::reverse_iterator<iterator>;
-    using const_reverse_iterator  = ETLSTD::reverse_iterator<const_iterator>;
-  
+template <typename T, size_t N> struct array {
+    using value_type = T;
+    using pointer = T *;
+    using const_pointer = const T *;
+    using reference = T &;
+    using const_reference = const T &;
+    using iterator = T *;
+    using const_iterator = const T *;
+    using size_type = size_t;
+    using difference_type = ptrdiff_t;
+    using reverse_iterator = ETLSTD::reverse_iterator<iterator>;
+    using const_reverse_iterator = ETLSTD::reverse_iterator<const_iterator>;
+
     // Access
-    reference operator[](size_type i) noexcept              { return elems[i]; }
-    constexpr const_reference operator[](size_type i) const  { return elems[i]; }
-    
-    reference at(size_type i)       { CheckRange(i); return elems[i]; }
-    constexpr const_reference at(size_type i) const { CheckRange(i); return elems[i]; }
-   
-    reference front() noexcept                        { return elems[0]; }
-    constexpr const_reference front() const noexcept  { return elems[0]; }
-    reference back() noexcept                         { return elems[N - 1]; }
-    constexpr const_reference back() const noexcept   { return elems[N - 1]; }
-    pointer data() noexcept                           { return elems; }
-    constexpr const_pointer data() const noexcept     { return elems; }
-    
+    reference operator[](size_type i) noexcept { return elems[i]; }
+    constexpr const_reference operator[](size_type i) const { return elems[i]; }
+
+    reference at(size_type i) {
+        CheckRange(i);
+        return elems[i];
+    }
+    constexpr const_reference at(size_type i) const {
+        CheckRange(i);
+        return elems[i];
+    }
+
+    reference front() noexcept { return elems[0]; }
+    constexpr const_reference front() const noexcept { return elems[0]; }
+    reference back() noexcept { return elems[N - 1]; }
+    constexpr const_reference back() const noexcept { return elems[N - 1]; }
+    pointer data() noexcept { return elems; }
+    constexpr const_pointer data() const noexcept { return elems; }
+
     // Size
     constexpr size_type size() const noexcept { return N; }
     constexpr size_type max_size() const noexcept { return N; }
     constexpr bool empty() const noexcept { return size() == 0; }
-    
+
     // Iterators
     iterator begin() noexcept { return elems; }
-    iterator end() noexcept   { return elems + N; }
-    
+    iterator end() noexcept { return elems + N; }
+
     const_iterator begin() const noexcept { return elems; }
-    const_iterator end() const noexcept   { return elems + N; }
-  
+    const_iterator end() const noexcept { return elems + N; }
+
     reverse_iterator rbegin() noexcept { return reverse_iterator(end()); }
-    reverse_iterator rend() noexcept   { return reverse_iterator(begin()); }
-    
+    reverse_iterator rend() noexcept { return reverse_iterator(begin()); }
+
     const_reverse_iterator rbegin() const noexcept { return const_reverse_iterator(end()); }
-    const_reverse_iterator rend() const noexcept   { return const_reverse_iterator(begin()); }
-   
+    const_reverse_iterator rend() const noexcept { return const_reverse_iterator(begin()); }
+
     const_iterator cbegin() const noexcept { return elems; }
-    const_iterator cend() const noexcept   { return elems + N; }
-  
+    const_iterator cend() const noexcept { return elems + N; }
+
     const_reverse_iterator crbegin() const noexcept { return const_reverse_iterator(end()); }
     const_reverse_iterator crend() const noexcept { return const_reverse_iterator(begin()); }
-    
+
     // Operations
-    void fill(const T& value) { fill_n(begin(), size(), value); }    
-    void swap(array& other) noexcept { swap_ranges(begin(), end(), other.begin()); }
-    
+    void fill(const T &value) { fill_n(begin(), size(), value); }
+    void swap(array &other) noexcept { swap_ranges(begin(), end(), other.begin()); }
+
 private:
     T elems[N];
-  
+
 private:
-    void CheckRange(size_type i) {
-        if (i >= size()) {
-            out_of_range exception("");
-            throw(exception);
-       }      
-    }    
+    static void CheckRange(size_type i) {
+        if (i >= N) {
+            throw out_of_range("");
+        }
+    }
 };
 
 // Zero-sized array specialization
-template<typename T>
-struct array<T, 0> {
-    using value_type        = T;
-    using pointer           = T*;
-    using const_pointer     = const T;
-    using reference         = T&;
-    using const_reference   = const T&;
-    using iterator          = T*;
-    using const_iterator    = const T*;
-    using size_type         = size_t;
-    using difference_type   = ptrdiff_t;
-    using reverse_iterator  = ETLSTD::reverse_iterator<iterator>;
-    using const_reverse_iterator  = ETLSTD::reverse_iterator<const_iterator>;
-  
+template <typename T> struct array<T, 0> {
+    using value_type = T;
+    using pointer = T *;
+    using const_pointer = const T *;
+    using reference = T &;
+    using const_reference = const T &;
+    using iterator = T *;
+    using const_iterator = const T *;
+    using size_type = size_t;
+    using difference_type = ptrdiff_t;
+    using reverse_iterator = ETLSTD::reverse_iterator<iterator>;
+    using const_reverse_iterator = ETLSTD::reverse_iterator<const_iterator>;
+
     // Access
-    reference operator[](size_type)                       { RangeError(); return elems; }
-    constexpr const_reference operator[](size_type) const { RangeError(); return elems; }   
-    reference at(size_type)                               { RangeError(); return elems; }
-    constexpr const_reference at(size_type) const         { RangeError(); return elems; }
-    reference front()                                     { RangeError(); return elems; }
-    constexpr const_reference front() const               { RangeError(); return elems; }
-    reference back()                                      { RangeError(); return elems; }
-    constexpr const_reference back() const                { RangeError(); return elems; }
-    pointer data() noexcept                               { return nullptr; }
-    constexpr const_pointer data() const noexcept         { return nullptr; }
-    
+    reference operator[](size_type) {
+        RangeError();
+        return *data();
+    }
+    constexpr const_reference operator[](size_type) const {
+        RangeError();
+        return *data();
+    }
+    reference at(size_type) {
+        RangeError();
+        return *data();
+    }
+    constexpr const_reference at(size_type) const {
+        RangeError();
+        return *data();
+    }
+    reference front() {
+        RangeError();
+        return *data();
+    }
+    constexpr const_reference front() const {
+        RangeError();
+        return *data();
+    }
+    reference back() {
+        RangeError();
+        return *data();
+    }
+    constexpr const_reference back() const {
+        RangeError();
+        return *data();
+    }
+    pointer data() noexcept { return nullptr; }
+    constexpr const_pointer data() const noexcept { return nullptr; }
+
     // Size
     constexpr size_type size() const noexcept { return 0; }
     constexpr size_type max_size() const noexcept { return 0; }
     constexpr bool empty() const noexcept { return true; }
-    
+
     // Iterators
-    iterator begin() noexcept { return iterator(reinterpret_cast<T*>(this)); }
-    iterator end() noexcept   { return begin(); }
-    
-    const_iterator begin() const noexcept { return const_iterator(reinterpret_cast<const T*>(this)); }
-    const_iterator end() const noexcept   { return begin(); }
-  
+    iterator begin() noexcept { return nullptr; }
+    iterator end() noexcept { return nullptr; }
+
+    const_iterator begin() const noexcept { return nullptr; }
+    const_iterator end() const noexcept { return nullptr; }
+
     reverse_iterator rbegin() noexcept { return reverse_iterator(end()); }
-    reverse_iterator rend() noexcept   { return reverse_iterator(begin()); }
-    
+    reverse_iterator rend() noexcept { return reverse_iterator(begin()); }
+
     const_reverse_iterator rbegin() const noexcept { return const_reverse_iterator(end()); }
-    const_reverse_iterator rend() const noexcept   { return const_reverse_iterator(begin()); }
-   
-    const_iterator cbegin() const noexcept { return const_iterator(reinterpret_cast<const T*>(this)); }
-    const_iterator cend() const noexcept   { return begin(); }
-  
+    const_reverse_iterator rend() const noexcept { return const_reverse_iterator(begin()); }
+
+    const_iterator cbegin() const noexcept { return nullptr; }
+    const_iterator cend() const noexcept { return nullptr; }
+
     const_reverse_iterator crbegin() const noexcept { return const_reverse_iterator(end()); }
     const_reverse_iterator crend() const noexcept { return const_reverse_iterator(begin()); }
-    
+
     // Operations
-    void fill(const T&) { }    
-    void swap(array&) noexcept { }
+    void fill(const T &) {}
+    void swap(array &) noexcept {}
 
 private:
-    T elems[0];
-
-private:
-    static void RangeError() {
-        std::out_of_range exception("");
-        throw(exception);
-    }      
+    [[noreturn]] static void RangeError() { throw out_of_range(""); }
 };
 
 // non-member functions
-template<typename T, size_t N >
-bool operator==(const array<T,N>& x, const array<T,N>& y) {
-  return equal( x.cbegin(), x.cend(), y.cbegin());
+template <typename T, size_t N> bool operator==(const array<T, N> &x, const array<T, N> &y) {
+    return equal(x.cbegin(), x.cend(), y.cbegin());
 }
-  
-template<typename T, size_t N >
-bool operator!=(const array<T,N>& x, const array<T,N>& y) {
-  return !(x == y);
-}  
 
-template<typename T, size_t N >
-bool operator<(const array<T,N>& x, const array<T,N>& y) {
-  return lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
-}  
+template <typename T, size_t N> bool operator!=(const array<T, N> &x, const array<T, N> &y) { return !(x == y); }
 
-template<typename T, size_t N >
-bool operator<=(const array<T,N>& x, const array<T,N>& y) {
-  return !(y < x);
-}  
+template <typename T, size_t N> bool operator<(const array<T, N> &x, const array<T, N> &y) {
+    return lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
 
-template<typename T, size_t N >
-bool operator>(const array<T,N>& x, const array<T,N>& y) {
-  return y < x;
-}  
+template <typename T, size_t N> bool operator<=(const array<T, N> &x, const array<T, N> &y) { return !(y < x); }
 
-template<typename T, size_t N >
-bool operator>=(const array<T,N>& x, const array<T,N>& y) {
-  return !(x < y);
-}  
+template <typename T, size_t N> bool operator>(const array<T, N> &x, const array<T, N> &y) { return y < x; }
+
+template <typename T, size_t N> bool operator>=(const array<T, N> &x, const array<T, N> &y) { return !(x < y); }
 
 } // namespace ETLSTD

--- a/libstd/include/h/array.h
+++ b/libstd/include/h/array.h
@@ -32,174 +32,181 @@
 //  POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <libstd/include/iterator>
 #include <libstd/include/algorithm>
+#include <libstd/include/iterator>
 #include <libstd/include/stdexcept>
 
 namespace ETLSTD {
 
-template<typename T, std::size_t N>
-struct array {
-  using value_type        = T;
-  using pointer           = T*;
-  using const_pointer     = const T;
-  using reference         = T&;
-  using const_reference   = const T&;
-  using iterator          = T*;
-  using const_iterator    = const T*;
-  using size_type         = size_t;
-  using difference_type   = ptrdiff_t;
-  using reverse_iterator  = reverse_iterator<iterator>;
-  using const_reverse_iterator  = std::reverse_iterator<const_iterator>;
-  
-  // Access
-  reference operator[](size_type i) noexcept              { return elems_[i]; }
-  constexpr const_reference operator[](size_type i) const  { return elems_[i]; }
-    
-  reference at(size_type i)       { CheckRange(i); return elems_[i]; }
-  constexpr const_reference at(size_type i) const { CheckRange(i); return elems_[i]; }
-   
-  reference front() noexcept                        { return elems_[0]; }
-  constexpr const_reference front() const noexcept  { return elems_[0]; }
-  reference back() noexcept                         { return elems_[N - 1]; }
-  constexpr const_reference back() const noexcept   { return elems_[N - 1]; }
-  pointer data() noexcept                           { return elems_; }
-  constexpr const_pointer data() const noexcept     { return elems_; }
-    
-  // Size
-  constexpr size_type size() const noexcept { return N; }
-  constexpr size_type max_size() const noexcept { return N; }
-  constexpr bool empty() const noexcept { return size() == 0; }
-    
-  // Iterators
-  iterator begin() noexcept { return elems_; }
-  iterator end() noexcept   { return elems_ + N; }
-    
-  const_iterator begin() const noexcept { return elems_; }
-  const_iterator end() const noexcept   { return elems_ + N; }
-  
-  reverse_iterator rbegin() noexcept { return reverse_iterator(end()); }
-  reverse_iterator rend() noexcept   { return reverse_iterator(begin()); }
-    
-  const_reverse_iterator rbegin() const noexcept { return const_reverse_iterator(end()); }
-  const_reverse_iterator rend() const noexcept   { return const_reverse_iterator(begin()); }
-   
-  const_iterator cbegin() const noexcept { return elems_; }
-  const_iterator cend() const noexcept   { return elems_ + N; }
-  
-  const_reverse_iterator crbegin() const noexcept { return const_reverse_iterator(end()); }
-  const_reverse_iterator crend() const noexcept { return const_reverse_iterator(begin()); }
-    
-  // Operations
-  void fill(const T& value) { std::fill_n(begin(), size(), value); }    
-  void swap(array& other) noexcept { std::swap_ranges(begin(), end(), other.begin()); }
-    
- private:
-  T elems_[N];
-  
- private:
-  static void CheckRange(size_type i) {
-    if (i >= size()) {
-      std::out_of_range exception("");
-      throw(exception);
-    }      
-  }    
+template <typename T, std::size_t N> struct array {
+    using value_type = T;
+    using pointer = T *;
+    using const_pointer = const T *;
+    using reference = T &;
+    using const_reference = const T &;
+    using iterator = T *;
+    using const_iterator = const T *;
+    using size_type = size_t;
+    using difference_type = ptrdiff_t;
+    using reverse_iterator = ETLSTD::reverse_iterator<iterator>;
+    using const_reverse_iterator = ETLSTD::reverse_iterator<const_iterator>;
+
+    // Access
+    reference operator[](size_type i) noexcept { return elems_[i]; }
+    constexpr const_reference operator[](size_type i) const { return elems_[i]; }
+
+    reference at(size_type i) {
+        CheckRange(i);
+        return elems_[i];
+    }
+    constexpr const_reference at(size_type i) const {
+        CheckRange(i);
+        return elems_[i];
+    }
+
+    reference front() noexcept { return elems_[0]; }
+    constexpr const_reference front() const noexcept { return elems_[0]; }
+    reference back() noexcept { return elems_[N - 1]; }
+    constexpr const_reference back() const noexcept { return elems_[N - 1]; }
+    pointer data() noexcept { return elems_; }
+    constexpr const_pointer data() const noexcept { return elems_; }
+
+    // Size
+    constexpr size_type size() const noexcept { return N; }
+    constexpr size_type max_size() const noexcept { return N; }
+    constexpr bool empty() const noexcept { return size() == 0; }
+
+    // Iterators
+    iterator begin() noexcept { return elems_; }
+    iterator end() noexcept { return elems_ + N; }
+
+    const_iterator begin() const noexcept { return elems_; }
+    const_iterator end() const noexcept { return elems_ + N; }
+
+    reverse_iterator rbegin() noexcept { return reverse_iterator(end()); }
+    reverse_iterator rend() noexcept { return reverse_iterator(begin()); }
+
+    const_reverse_iterator rbegin() const noexcept { return const_reverse_iterator(end()); }
+    const_reverse_iterator rend() const noexcept { return const_reverse_iterator(begin()); }
+
+    const_iterator cbegin() const noexcept { return elems_; }
+    const_iterator cend() const noexcept { return elems_ + N; }
+
+    const_reverse_iterator crbegin() const noexcept { return const_reverse_iterator(end()); }
+    const_reverse_iterator crend() const noexcept { return const_reverse_iterator(begin()); }
+
+    // Operations
+    void fill(const T &value) { std::fill_n(begin(), size(), value); }
+    void swap(array &other) noexcept { std::swap_ranges(begin(), end(), other.begin()); }
+
+private:
+    T elems_[N];
+
+private:
+    static void CheckRange(size_type i) {
+        if (i >= N) {
+            throw out_of_range("");
+        }
+    }
 };
 
 // Zero-sized array specialization
-template<typename T>
-struct array<T, 0> {
-  using value_type        = T;
-  using pointer           = T*;
-  using const_pointer     = const T;
-  using reference         = T&;
-  using const_reference   = const T&;
-  using iterator          = T*;
-  using const_iterator    = const T*;
-  using size_type         = size_t;
-  using difference_type   = ptrdiff_t;
-  using reverse_iterator  = reverse_iterator<iterator>;
-  using const_reverse_iterator  = reverse_iterator<const_iterator>;
-  
-  // Access
-  reference operator[](size_type)                       { RangeError(); return elems_; }
-  constexpr const_reference operator[](size_type) const { RangeError(); return elems_; }   
-  reference at(size_type)                               { RangeError(); return elems_; }
-  constexpr const_reference at(size_type) const         { RangeError(); return elems_; }
-  reference front()                                     { RangeError(); return elems_; }
-  constexpr const_reference front() const               { RangeError(); return elems_; }
-  reference back()                                      { RangeError(); return elems_; }
-  constexpr const_reference back() const                { RangeError(); return elems_; }
-  pointer data() noexcept                               { return nullptr; }
-  constexpr const_pointer data() const noexcept         { return nullptr; }
-    
-  // Size
-  constexpr size_type size() const noexcept { return 0; }
-  constexpr size_type max_size() const noexcept { return 0; }
-  constexpr bool empty() const noexcept { return true; }
-    
-  // Iterators
-  iterator begin() noexcept { return iterator(reinterpret_cast<T*>(this)); }
-  iterator end() noexcept   { return begin(); }
-    
-  const_iterator begin() const noexcept { return const_iterator(reinterpret_cast<const T*>(this)); }
-  const_iterator end() const noexcept   { return begin(); }
-  
-  reverse_iterator rbegin() noexcept { return reverse_iterator(end()); }
-  reverse_iterator rend() noexcept   { return reverse_iterator(begin()); }
-    
-  const_reverse_iterator rbegin() const noexcept { return const_reverse_iterator(end()); }
-  const_reverse_iterator rend() const noexcept   { return const_reverse_iterator(begin()); }
-   
-  const_iterator cbegin() const noexcept { return const_iterator(reinterpret_cast<const T*>(this)); }
-  const_iterator cend() const noexcept   { return begin(); }
-  
-  const_reverse_iterator crbegin() const noexcept { return const_reverse_iterator(end()); }
-  const_reverse_iterator crend() const noexcept { return const_reverse_iterator(begin()); }
-    
-  // Operations
-  void fill(const T&) { }    
-  void swap(array&) noexcept { }
+template <typename T> struct array<T, 0> {
+    using value_type = T;
+    using pointer = T *;
+    using const_pointer = const T *;
+    using reference = T &;
+    using const_reference = const T &;
+    using iterator = T *;
+    using const_iterator = const T *;
+    using size_type = size_t;
+    using difference_type = ptrdiff_t;
+    using reverse_iterator = ETLSTD::reverse_iterator<iterator>;
+    using const_reverse_iterator = ETLSTD::reverse_iterator<const_iterator>;
 
- private:
-  T elems_[0];
+    // Access
+    reference operator[](size_type) {
+        RangeError();
+        return *data();
+    }
+    constexpr const_reference operator[](size_type) const {
+        RangeError();
+        return *data();
+    }
+    reference at(size_type) {
+        RangeError();
+        return *data();
+    }
+    constexpr const_reference at(size_type) const {
+        RangeError();
+        return *data();
+    }
+    reference front() {
+        RangeError();
+        return *data();
+    }
+    constexpr const_reference front() const {
+        RangeError();
+        return *data();
+    }
+    reference back() {
+        RangeError();
+        return *data();
+    }
+    constexpr const_reference back() const {
+        RangeError();
+        return *data();
+    }
+    pointer data() noexcept { return nullptr; }
+    constexpr const_pointer data() const noexcept { return nullptr; }
 
- private:
-  static void RangeError() {
-    std::out_of_range exception("");
-    throw(exception);
-  }      
+    // Size
+    constexpr size_type size() const noexcept { return 0; }
+    constexpr size_type max_size() const noexcept { return 0; }
+    constexpr bool empty() const noexcept { return true; }
+
+    // Iterators
+    iterator begin() noexcept { return nullptr; }
+    iterator end() noexcept { return nullptr; }
+
+    const_iterator begin() const noexcept { return nullptr; }
+    const_iterator end() const noexcept { return nullptr; }
+
+    reverse_iterator rbegin() noexcept { return reverse_iterator(end()); }
+    reverse_iterator rend() noexcept { return reverse_iterator(begin()); }
+
+    const_reverse_iterator rbegin() const noexcept { return const_reverse_iterator(end()); }
+    const_reverse_iterator rend() const noexcept { return const_reverse_iterator(begin()); }
+
+    const_iterator cbegin() const noexcept { return nullptr; }
+    const_iterator cend() const noexcept { return nullptr; }
+
+    const_reverse_iterator crbegin() const noexcept { return const_reverse_iterator(end()); }
+    const_reverse_iterator crend() const noexcept { return const_reverse_iterator(begin()); }
+
+    // Operations
+    void fill(const T &) {}
+    void swap(array &) noexcept {}
+
+private:
+    [[noreturn]] static void RangeError() { throw out_of_range(""); }
 };
 
 // non-member functions
-template<typename T, size_t N >
-bool operator==(const array<T,N>& x, const array<T,N>& y) {
-  return equal( x.cbegin(), x.cend(), y.cbegin());
+template <typename T, size_t N> bool operator==(const array<T, N> &x, const array<T, N> &y) {
+    return equal(x.cbegin(), x.cend(), y.cbegin());
 }
-  
-template<typename T, size_t N >
-bool operator!=(const array<T,N>& x, const array<T,N>& y) {
-  return !(x == y);
-}  
 
-template<typename T, size_t N >
-bool operator<(const array<T,N>& x, const array<T,N>& y) {
-  return lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
-}  
+template <typename T, size_t N> bool operator!=(const array<T, N> &x, const array<T, N> &y) { return !(x == y); }
 
-template<typename T, size_t N >
-bool operator<=(const array<T,N>& x, const array<T,N>& y) {
-  return !(y < x);
-}  
+template <typename T, size_t N> bool operator<(const array<T, N> &x, const array<T, N> &y) {
+    return lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
 
-template<typename T, size_t N >
-bool operator>(const array<T,N>& x, const array<T,N>& y) {
-  return y < x;
-}  
+template <typename T, size_t N> bool operator<=(const array<T, N> &x, const array<T, N> &y) { return !(y < x); }
 
-template<typename T, size_t N >
-bool operator>=(const array<T,N>& x, const array<T,N>& y) {
-  return !(x < y);
-}  
+template <typename T, size_t N> bool operator>(const array<T, N> &x, const array<T, N> &y) { return y < x; }
+
+template <typename T, size_t N> bool operator>=(const array<T, N> &x, const array<T, N> &y) { return !(x < y); }
 
 } // namespace ETLSTD

--- a/libstd/include/h/array.h
+++ b/libstd/include/h/array.h
@@ -96,8 +96,8 @@ template <typename T, std::size_t N> struct array {
     const_reverse_iterator crend() const noexcept { return const_reverse_iterator(begin()); }
 
     // Operations
-    void fill(const T &value) { std::fill_n(begin(), size(), value); }
-    void swap(array &other) noexcept { std::swap_ranges(begin(), end(), other.begin()); }
+    void fill(const T &value) { fill_n(begin(), size(), value); }
+    void swap(array &other) noexcept { swap_ranges(begin(), end(), other.begin()); }
 
 private:
     T elems_[N];

--- a/libstd/include/stdexcept
+++ b/libstd/include/stdexcept
@@ -37,69 +37,68 @@
 namespace ETLSTD {
 
 class logic_error : public exception {
- public:
-  logic_error() throw();
-  explicit logic_error(const char* /*what_arg*/) {}
-  virtual ~logic_error() throw() {}
-  virtual const char* what() const throw() { return nullptr; }
-};	
+public:
+    logic_error() throw() {}
+    explicit logic_error(const char * /*what_arg*/) {}
+    virtual ~logic_error() throw() {}
+    virtual const char *what() const throw() { return nullptr; }
+};
 
 class domain_error : public logic_error {
- public:
-  domain_error() : logic_error() {}
-  explicit domain_error(const char* what_arg) : logic_error(what_arg) {}
-  virtual ~domain_error() throw() {}
+public:
+    domain_error() : logic_error() {}
+    explicit domain_error(const char *what_arg) : logic_error(what_arg) {}
+    virtual ~domain_error() throw() {}
 };
 
 class invalid_argument : public logic_error {
- public:
-  invalid_argument() : logic_error() {}
-  explicit invalid_argument(const char* what_arg) : logic_error(what_arg) {}
-  virtual ~invalid_argument() throw() {}
+public:
+    invalid_argument() : logic_error() {}
+    explicit invalid_argument(const char *what_arg) : logic_error(what_arg) {}
+    virtual ~invalid_argument() throw() {}
 };
 
 class length_error : public logic_error {
- public:
-  length_error() : logic_error() {}
-  explicit length_error(const char* what_arg) : logic_error(what_arg){}
-  virtual ~length_error() throw() {}
+public:
+    length_error() : logic_error() {}
+    explicit length_error(const char *what_arg) : logic_error(what_arg) {}
+    virtual ~length_error() throw() {}
 };
 
-class out_of_range : public logic_error{
- public:
-  out_of_range();
-  explicit out_of_range(const char* what_arg);
-  virtual ~out_of_range() throw() {}
+class out_of_range : public logic_error {
+public:
+    out_of_range() : logic_error() {}
+    explicit out_of_range(const char *what_arg) : logic_error(what_arg) {}
+    virtual ~out_of_range() throw() {}
 };
 
 class runtime_error : public exception {
- public:
-  runtime_error();
-  explicit runtime_error(const char* /*what_arg*/) {}
-  virtual ~runtime_error() throw() {}
-  virtual const char* what() const throw() { return nullptr; };
+public:
+    runtime_error() {}
+    explicit runtime_error(const char * /*what_arg*/) {}
+    virtual ~runtime_error() throw() {}
+    virtual const char *what() const throw() { return nullptr; };
 };
 
 class range_error : public runtime_error {
- public:
-  range_error() : runtime_error() {}
-  explicit range_error(const char* what_arg) : runtime_error(what_arg) {}
-  virtual ~range_error() throw() {}
+public:
+    range_error() : runtime_error() {}
+    explicit range_error(const char *what_arg) : runtime_error(what_arg) {}
+    virtual ~range_error() throw() {}
 };
 
-
 class overflow_error : public runtime_error {
- public:
-  overflow_error() : runtime_error() {}
-  explicit overflow_error(const char* what_arg) : runtime_error(what_arg) {}
-  virtual ~overflow_error() throw() {}
+public:
+    overflow_error() : runtime_error() {}
+    explicit overflow_error(const char *what_arg) : runtime_error(what_arg) {}
+    virtual ~overflow_error() throw() {}
 };
 
 class underflow_error : public runtime_error {
- public:
-  underflow_error() : runtime_error() {}
-  explicit underflow_error(const char* what_arg) : runtime_error(what_arg) {}
-  virtual ~underflow_error() throw() {}
+public:
+    underflow_error() : runtime_error() {}
+    explicit underflow_error(const char *what_arg) : runtime_error(what_arg) {}
+    virtual ~underflow_error() throw() {}
 };
 
 } // namespace ETLSTD

--- a/test/libstd/array.cpp
+++ b/test/libstd/array.cpp
@@ -1,0 +1,97 @@
+/// @file test/libstd/array.cpp
+/// @date 01/07/2026
+/// @author Ambroise Leclerc
+/// @brief Tests for <array>
+//
+// Copyright (c) 2026, Ambroise Leclerc
+//   All rights reserved.
+//
+//   Redistribution and use in source and binary forms, with or without
+//   modification, are permitted provided that the following conditions are met:
+//
+//   * Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in
+//     the documentation and/or other materials provided with the
+//     distribution.
+//   * Neither the name of the copyright holders nor the names of
+//     contributors may be used to endorse or promote products derived
+//     from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+#include <catch.hpp>
+
+#define __Mock_Mock__
+#define ETLSTD etlstd
+
+#include <libstd/include/array>
+#include <libstd/include/stdexcept>
+#include <libstd/include/type_traits>
+
+using namespace ETLSTD;
+
+SCENARIO("std::array const accessors") {
+    array<int, 3> values;
+    values[0] = 1;
+    values[1] = 2;
+    values[2] = 3;
+    const array<int, 3> &constValues = values;
+    using const_pointer = typename array<int, 3>::const_pointer;
+    using const_data_type = decltype(constValues.data());
+
+    REQUIRE((is_same_v<const_pointer, const int *>));
+    REQUIRE((is_same_v<const_data_type, const int *>));
+
+    REQUIRE(constValues.data() == values.data());
+    REQUIRE(constValues.front() == 1);
+    REQUIRE(constValues.back() == 3);
+    REQUIRE(constValues[1] == 2);
+    REQUIRE(constValues.at(2) == 3);
+
+    REQUIRE(constValues.rbegin().base() == constValues.end());
+    REQUIRE(*constValues.rbegin() == 3);
+    REQUIRE(constValues.rend().base() == constValues.begin());
+
+    REQUIRE(constValues.crbegin().base() == constValues.cend());
+    REQUIRE(*constValues.crbegin() == 3);
+    REQUIRE(constValues.crend().base() == constValues.cbegin());
+}
+
+SCENARIO("std::array zero-sized specialization") {
+    array<int, 0> values{};
+    const array<int, 0> &constValues = values;
+
+    REQUIRE(values.empty());
+    REQUIRE(values.size() == 0);
+    REQUIRE(values.max_size() == 0);
+
+    REQUIRE(values.data() == nullptr);
+    REQUIRE(constValues.data() == nullptr);
+    REQUIRE(values.begin() == values.end());
+    REQUIRE(constValues.begin() == constValues.end());
+    REQUIRE(values.cbegin() == values.cend());
+    REQUIRE(constValues.cbegin() == constValues.cend());
+    REQUIRE(values.rbegin().base() == values.end());
+    REQUIRE(constValues.rbegin().base() == constValues.end());
+    REQUIRE(constValues.crbegin().base() == constValues.cend());
+
+    REQUIRE_THROWS_AS(values[0], out_of_range);
+    REQUIRE_THROWS_AS(constValues[0], out_of_range);
+    REQUIRE_THROWS_AS(values.at(0), out_of_range);
+    REQUIRE_THROWS_AS(constValues.at(0), out_of_range);
+    REQUIRE_THROWS_AS(values.front(), out_of_range);
+    REQUIRE_THROWS_AS(constValues.front(), out_of_range);
+    REQUIRE_THROWS_AS(values.back(), out_of_range);
+    REQUIRE_THROWS_AS(constValues.back(), out_of_range);
+}


### PR DESCRIPTION
## Summary
- `const_pointer` was aliased to `const T` instead of `const T*`, so `data() const` returned type `const T` rather than a pointer — fixed in both `libstd/include/array` and the unused `libstd/include/h/array.h` mirror.
- Replaced the zero-size `array<T,0>` specialization's GCC-extension tricks (zero-length member array + `reinterpret_cast<T*>(this)` for begin/end) with `nullptr`/`data()`-based logic.
- `CheckRange`/`RangeError` now actually `throw out_of_range(...)` instead of constructing-and-discarding a local exception object that was never thrown.
- Added `test/libstd/array.cpp`, registered in `LIBSTD_TESTS`, covering const accessors and the zero-size specialization (data/size/begin==end/throwing accessors).

Rebased onto current master (which contains the AVR ioports fix from #100); original branch was forked before that fix and had an unrelated red CI.

## Test plan
- [x] `cmake -S . -B build && cmake --build build -j$(nproc)`
- [x] `ctest --test-dir build --output-on-failure` — all tests pass

Fixes #96