### PR TITLE
Expand libstd validation coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,7 @@ jobs:
       - name: Build AVR smoke target
         run: cmake --build build-avr
 
-      - name: Check HEX output
-        run: test -f build-avr/etl_avr_smoke.hex
+      - name: Check HEX outputs
+        run: |
+          test -f build-avr/etl_avr_smoke.hex
+          test -f build-avr/etl_avr_libstd_smoke.hex

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ if (ETL_BUILD_HOST_TESTS)
     include(CTest)
     if (BUILD_TESTING)
         add_test(NAME TestsETL COMMAND TestsETL)
+        add_test(NAME TestsETL-libstd COMMAND TestsETL [libstd])
     endif()
 
     set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT TestsETL)
@@ -70,24 +71,29 @@ if (ETL_BUILD_AVR_SMOKE)
         message(FATAL_ERROR "ETL_BUILD_AVR_SMOKE requires an AVR toolchain. Configure with -DCMAKE_TOOLCHAIN_FILE=cmake/avr-gcc-toolchain.cmake.")
     endif()
 
-    add_executable(etl_avr_smoke
-        examples/avr/smoke.cpp
-        ${HEADERS}
-    )
-
-    target_link_libraries(etl_avr_smoke PRIVATE etl)
-    target_compile_features(etl_avr_smoke PRIVATE cxx_std_23)
-    target_compile_definitions(etl_avr_smoke PRIVATE F_CPU=${ETL_AVR_F_CPU})
-    target_compile_options(etl_avr_smoke PRIVATE -Os -ffunction-sections -fdata-sections)
-    target_link_options(etl_avr_smoke PRIVATE -Wl,--gc-sections)
-    set_target_properties(etl_avr_smoke PROPERTIES OUTPUT_NAME "etl_avr_smoke" SUFFIX ".elf")
-
-    if (CMAKE_OBJCOPY)
-        add_custom_command(
-            TARGET etl_avr_smoke POST_BUILD
-            COMMAND ${CMAKE_OBJCOPY} -O ihex -R .eeprom $<TARGET_FILE:etl_avr_smoke> ${CMAKE_CURRENT_BINARY_DIR}/etl_avr_smoke.hex
-            BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/etl_avr_smoke.hex
-            COMMENT "Generating Intel HEX image"
+    function(etl_add_avr_smoke_target target_name source_file)
+        add_executable(${target_name}
+            ${source_file}
+            ${HEADERS}
         )
-    endif()
+
+        target_link_libraries(${target_name} PRIVATE etl)
+        target_compile_features(${target_name} PRIVATE cxx_std_23)
+        target_compile_definitions(${target_name} PRIVATE F_CPU=${ETL_AVR_F_CPU})
+        target_compile_options(${target_name} PRIVATE -Os -ffunction-sections -fdata-sections)
+        target_link_options(${target_name} PRIVATE -Wl,--gc-sections)
+        set_target_properties(${target_name} PROPERTIES OUTPUT_NAME "${target_name}" SUFFIX ".elf")
+
+        if (CMAKE_OBJCOPY)
+            add_custom_command(
+                TARGET ${target_name} POST_BUILD
+                COMMAND ${CMAKE_OBJCOPY} -O ihex -R .eeprom $<TARGET_FILE:${target_name}> ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.hex
+                BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.hex
+                COMMENT "Generating Intel HEX image for ${target_name}"
+            )
+        endif()
+    endfunction()
+
+    etl_add_avr_smoke_target(etl_avr_smoke examples/avr/smoke.cpp)
+    etl_add_avr_smoke_target(etl_avr_libstd_smoke examples/avr/libstd_smoke.cpp)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if (ETL_BUILD_HOST_TESTS)
 
     include(CTest)
     if (BUILD_TESTING)
-        add_test(NAME TestsETL COMMAND TestsETL)
+        add_test(NAME TestsETL COMMAND TestsETL ~[libstd])
         add_test(NAME TestsETL-libstd COMMAND TestsETL [libstd])
     endif()
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Useful test runner commands:
 ```sh
 ./build/TestsETL --list-tests
 ./build/TestsETL '[GPIO]'
+./build/TestsETL '[libstd]'
 ./build/TestsETL 'Scenario: std::tuple'
 ```
 
@@ -150,6 +151,8 @@ That produces:
 
 - `build-avr/etl_avr_smoke.elf`
 - `build-avr/etl_avr_smoke.hex`
+- `build-avr/etl_avr_libstd_smoke.elf`
+- `build-avr/etl_avr_libstd_smoke.hex`
 
 You can override `ETL_AVR_MCU` to validate another supported MCU such as `attiny84`.
 

--- a/examples/avr/libstd_smoke.cpp
+++ b/examples/avr/libstd_smoke.cpp
@@ -1,0 +1,18 @@
+#define ETLSTD etlstd
+
+#include <etl.h>
+#include <etl/CircularBuffer.h>
+#include <libstd/include/array>
+#include <libstd/include/chrono>
+#include <libstd/include/queue>
+#include <libstd/include/string_view>
+
+int main() {
+    constexpr ETLSTD::string_view text("avr-libstd");
+    ETLSTD::array<unsigned char, 3> data{{1, 2, 3}};
+    ETLSTD::queue<unsigned char, etl::CircularBuffer<unsigned char, 4>> fifo;
+    fifo.push(data[0]);
+    fifo.push(static_cast<unsigned char>(ETLSTD::chrono::milliseconds(2).count()));
+
+    return text.starts_with("avr") && fifo.front() == 1 ? 0 : 1;
+}

--- a/include/etl/architecture/ioports_ATmega328P.h
+++ b/include/etl/architecture/ioports_ATmega328P.h
@@ -19,7 +19,7 @@
 //     contributors may be used to endorse or promote products derived
 //     from this software without specific prior written permission.
 //
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' 
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
 //  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 //  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 //  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
@@ -32,22 +32,22 @@
 //  POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <util/delay.h>
-#include <avr/io.h>
+#include "ETLDevice_ATmega328P.h"
 #include <avr/interrupt.h>
+#include <avr/io.h>
+#include <etl/CircularBuffer.h>
 #include <libstd/include/chrono>
 #include <libstd/include/queue>
-#include <etl/CircularBuffer.h>
-#include "ETLDevice_ATmega328P.h"
+#include <util/delay.h>
 
 extern void __builtin_avr_delay_cycles(unsigned long);
 
 namespace etl {
 #define IOPORTS_TO_STRING(name) #name
-#define IOPORTS_IRQ_HANDLER(vector, type) asm(IOPORTS_TO_STRING(vector)) __attribute__ ((type, __INTR_ATTRS))
+#define IOPORTS_IRQ_HANDLER(vector, type) asm(IOPORTS_TO_STRING(vector)) __attribute__((type, __INTR_ATTRS))
 
-using clock_cycles = std::chrono::duration<unsigned long, std::ratio<1, Device::McuFrequency>>;
-constexpr clock_cycles operator ""_clks(unsigned long long c)     { return clock_cycles(static_cast<clock_cycles::rep>(c)); }
+using clock_cycles = ETLSTD::chrono::duration<unsigned long, ETLSTD::ratio<1, Device::McuFrequency>>;
+constexpr clock_cycles operator""_clks(unsigned long long c) { return clock_cycles(static_cast<clock_cycles::rep>(c)); }
 struct PinChangeIRQ0;
 struct PinChangeIRQ1;
 struct PinChangeIRQ2;
@@ -57,91 +57,105 @@ struct PortB {
 
     /// Assigns a value to PORTB
     /// @param[in] value value affected to PORTB
-    static void assign(uint8_t value)   { PORTB = value; }
+    static void assign(uint8_t value) { PORTB = value; }
 
     /// Sets masked bits in PORTB
     /// @param[in] mask bits to set
-    static void setBits(uint8_t mask)   { PORTB |= mask;}
+    static void setBits(uint8_t mask) { PORTB |= mask; }
 
     /// Clears masked bits in PORTB
     /// @param[in] mask bits to clear
-    static void clearBits(uint8_t mask) { PORTB &= ~mask;} 
+    static void clearBits(uint8_t mask) { PORTB &= ~mask; }
 
     /// Changes values of masked bits in PORTB
     /// @param[in] mask bits to change
     /// @param[in] value new bits values
-    static void changeBits(uint8_t mask, uint8_t value) { uint8_t tmp = PORTB & ~mask; PORTB = tmp | value; } 
+    static void changeBits(uint8_t mask, uint8_t value) {
+        uint8_t tmp = PORTB & ~mask;
+        PORTB = tmp | value;
+    }
 
     /// Toggles masked bits in PORTB
     /// @param[in] mask bits to toggle
-    static void toggleBits(uint8_t mask) { PORTB ^= mask;} 
+    static void toggleBits(uint8_t mask) { PORTB ^= mask; }
 
     /// Pulses masked bits in PORTB with high state first.
     /// @param[in] mask bits to pulse
-    static void pulseHigh(uint8_t mask) { PORTB |= mask; PORTB &= ~mask; }
+    static void pulseHigh(uint8_t mask) {
+        PORTB |= mask;
+        PORTB &= ~mask;
+    }
 
     /// Pulses masked bits in PORTB with low state first.
     /// @param[in] mask bits to pulse
-    static void pulseLow(uint8_t mask)  { PORTB &= ~mask; PORTB |= mask; }
+    static void pulseLow(uint8_t mask) {
+        PORTB &= ~mask;
+        PORTB |= mask;
+    }
 
     /// Set corresponding masked bits of PORTB to output direction.
     /// @param[in] mask bits
-    static void setOutput(uint8_t mask)    { DDRB |= mask; }
+    static void setOutput(uint8_t mask) { DDRB |= mask; }
 
     /// Set corresponding masked bits of PORTB to input direction.
     /// @param[in] mask bits
-    static void setInput(uint8_t mask)  { DDRB &= ~mask; }
+    static void setInput(uint8_t mask) { DDRB &= ~mask; }
 
     /// Returns PINB register.
-    static uint8_t getPIN()             { return PINB; }
+    static uint8_t getPIN() { return PINB; }
 
     /// Tests masked bits of PORTB
     /// @param[in] mask bits
     /// @param[in] true if the corresponding bits are all set, false otherwise.
-    static bool testBits(uint8_t mask)  { return (PINB & mask) == mask; }
+    static bool testBits(uint8_t mask) { return (PINB & mask) == mask; }
 
     /// Returns the value of the bit at the position pos.
     /// @param[in] position of the bit to return
     /// @return true if the requested bit is set, false otherwise.
-    static bool test(uint8_t pos) { return PINB & (1<<pos); }
-
+    static bool test(uint8_t pos) { return PINB & (1 << pos); }
 };
 
 struct PinB7 {
     /// Sets PinB7 to HIGH.
-    static void set()       { PORTB |= (1<<7); }
+    static void set() { PORTB |= (1 << 7); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinB7 to LOW.
-    static void clear()     { PORTB &= ~(1<<7); }
+    static void clear() { PORTB &= ~(1 << 7); }
 
     /// Toggles PinB7 value.
-    static void toggle()    { PINB |= (1<<7); }
+    static void toggle() { PINB |= (1 << 7); }
 
     /// Configures PinB7  as an output pin.
-    static void setOutput() { DDRB |= (1<<7); }
+    static void setOutput() { DDRB |= (1 << 7); }
 
     /// Configures PinB7  as an input pin.
-    static void setInput()  { DDRB &= ~(1<<7); }
+    static void setInput() { DDRB &= ~(1 << 7); }
 
     /// Pulses PinB7 with high state first.
-    static void pulseHigh() { PORTB |= (1<<7); PORTB &= ~(1<<7); }
+    static void pulseHigh() {
+        PORTB |= (1 << 7);
+        PORTB &= ~(1 << 7);
+    }
 
     /// Pulses PinB7 with low state first.
-    static void pulseLow()  { PORTB &= ~(1<<7); PORTB |= (1<<7); }
+    static void pulseLow() {
+        PORTB &= ~(1 << 7);
+        PORTB |= (1 << 7);
+    }
 
     /// Reads PinB7  value.
     /// @return Port pin value.
-    static bool test()      { return PINB & (1<<7); }
+    static bool test() { return PINB & (1 << 7); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<7)
-    static constexpr uint8_t bitmask()               { return (1<<7); }
+    static constexpr uint8_t bitmask() { return (1 << 7); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 7
-    static constexpr uint8_t bit()                   { return 7; }
+    static constexpr uint8_t bit() { return 7; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortB;
@@ -149,39 +163,45 @@ struct PinB7 {
 
 struct PinB6 {
     /// Sets PinB6 to HIGH.
-    static void set()       { PORTB |= (1<<6); }
+    static void set() { PORTB |= (1 << 6); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinB6 to LOW.
-    static void clear()     { PORTB &= ~(1<<6); }
+    static void clear() { PORTB &= ~(1 << 6); }
 
     /// Toggles PinB6 value.
-    static void toggle()    { PINB |= (1<<6); }
+    static void toggle() { PINB |= (1 << 6); }
 
     /// Configures PinB6  as an output pin.
-    static void setOutput() { DDRB |= (1<<6); }
+    static void setOutput() { DDRB |= (1 << 6); }
 
     /// Configures PinB6  as an input pin.
-    static void setInput()  { DDRB &= ~(1<<6); }
+    static void setInput() { DDRB &= ~(1 << 6); }
 
     /// Pulses PinB6 with high state first.
-    static void pulseHigh() { PORTB |= (1<<6); PORTB &= ~(1<<6); }
+    static void pulseHigh() {
+        PORTB |= (1 << 6);
+        PORTB &= ~(1 << 6);
+    }
 
     /// Pulses PinB6 with low state first.
-    static void pulseLow()  { PORTB &= ~(1<<6); PORTB |= (1<<6); }
+    static void pulseLow() {
+        PORTB &= ~(1 << 6);
+        PORTB |= (1 << 6);
+    }
 
     /// Reads PinB6  value.
     /// @return Port pin value.
-    static bool test()      { return PINB & (1<<6); }
+    static bool test() { return PINB & (1 << 6); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<6)
-    static constexpr uint8_t bitmask()               { return (1<<6); }
+    static constexpr uint8_t bitmask() { return (1 << 6); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 6
-    static constexpr uint8_t bit()                   { return 6; }
+    static constexpr uint8_t bit() { return 6; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortB;
@@ -189,39 +209,45 @@ struct PinB6 {
 
 struct PinB5 {
     /// Sets PinB5 to HIGH.
-    static void set()       { PORTB |= (1<<5); }
+    static void set() { PORTB |= (1 << 5); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinB5 to LOW.
-    static void clear()     { PORTB &= ~(1<<5); }
+    static void clear() { PORTB &= ~(1 << 5); }
 
     /// Toggles PinB5 value.
-    static void toggle()    { PINB |= (1<<5); }
+    static void toggle() { PINB |= (1 << 5); }
 
     /// Configures PinB5  as an output pin.
-    static void setOutput() { DDRB |= (1<<5); }
+    static void setOutput() { DDRB |= (1 << 5); }
 
     /// Configures PinB5  as an input pin.
-    static void setInput()  { DDRB &= ~(1<<5); }
+    static void setInput() { DDRB &= ~(1 << 5); }
 
     /// Pulses PinB5 with high state first.
-    static void pulseHigh() { PORTB |= (1<<5); PORTB &= ~(1<<5); }
+    static void pulseHigh() {
+        PORTB |= (1 << 5);
+        PORTB &= ~(1 << 5);
+    }
 
     /// Pulses PinB5 with low state first.
-    static void pulseLow()  { PORTB &= ~(1<<5); PORTB |= (1<<5); }
+    static void pulseLow() {
+        PORTB &= ~(1 << 5);
+        PORTB |= (1 << 5);
+    }
 
     /// Reads PinB5  value.
     /// @return Port pin value.
-    static bool test()      { return PINB & (1<<5); }
+    static bool test() { return PINB & (1 << 5); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<5)
-    static constexpr uint8_t bitmask()               { return (1<<5); }
+    static constexpr uint8_t bitmask() { return (1 << 5); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 5
-    static constexpr uint8_t bit()                   { return 5; }
+    static constexpr uint8_t bit() { return 5; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortB;
@@ -229,39 +255,45 @@ struct PinB5 {
 
 struct PinB4 {
     /// Sets PinB4 to HIGH.
-    static void set()       { PORTB |= (1<<4); }
+    static void set() { PORTB |= (1 << 4); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinB4 to LOW.
-    static void clear()     { PORTB &= ~(1<<4); }
+    static void clear() { PORTB &= ~(1 << 4); }
 
     /// Toggles PinB4 value.
-    static void toggle()    { PINB |= (1<<4); }
+    static void toggle() { PINB |= (1 << 4); }
 
     /// Configures PinB4  as an output pin.
-    static void setOutput() { DDRB |= (1<<4); }
+    static void setOutput() { DDRB |= (1 << 4); }
 
     /// Configures PinB4  as an input pin.
-    static void setInput()  { DDRB &= ~(1<<4); }
+    static void setInput() { DDRB &= ~(1 << 4); }
 
     /// Pulses PinB4 with high state first.
-    static void pulseHigh() { PORTB |= (1<<4); PORTB &= ~(1<<4); }
+    static void pulseHigh() {
+        PORTB |= (1 << 4);
+        PORTB &= ~(1 << 4);
+    }
 
     /// Pulses PinB4 with low state first.
-    static void pulseLow()  { PORTB &= ~(1<<4); PORTB |= (1<<4); }
+    static void pulseLow() {
+        PORTB &= ~(1 << 4);
+        PORTB |= (1 << 4);
+    }
 
     /// Reads PinB4  value.
     /// @return Port pin value.
-    static bool test()      { return PINB & (1<<4); }
+    static bool test() { return PINB & (1 << 4); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<4)
-    static constexpr uint8_t bitmask()               { return (1<<4); }
+    static constexpr uint8_t bitmask() { return (1 << 4); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 4
-    static constexpr uint8_t bit()                   { return 4; }
+    static constexpr uint8_t bit() { return 4; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortB;
@@ -269,39 +301,45 @@ struct PinB4 {
 
 struct PinB3 {
     /// Sets PinB3 to HIGH.
-    static void set()       { PORTB |= (1<<3); }
+    static void set() { PORTB |= (1 << 3); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinB3 to LOW.
-    static void clear()     { PORTB &= ~(1<<3); }
+    static void clear() { PORTB &= ~(1 << 3); }
 
     /// Toggles PinB3 value.
-    static void toggle()    { PINB |= (1<<3); }
+    static void toggle() { PINB |= (1 << 3); }
 
     /// Configures PinB3  as an output pin.
-    static void setOutput() { DDRB |= (1<<3); }
+    static void setOutput() { DDRB |= (1 << 3); }
 
     /// Configures PinB3  as an input pin.
-    static void setInput()  { DDRB &= ~(1<<3); }
+    static void setInput() { DDRB &= ~(1 << 3); }
 
     /// Pulses PinB3 with high state first.
-    static void pulseHigh() { PORTB |= (1<<3); PORTB &= ~(1<<3); }
+    static void pulseHigh() {
+        PORTB |= (1 << 3);
+        PORTB &= ~(1 << 3);
+    }
 
     /// Pulses PinB3 with low state first.
-    static void pulseLow()  { PORTB &= ~(1<<3); PORTB |= (1<<3); }
+    static void pulseLow() {
+        PORTB &= ~(1 << 3);
+        PORTB |= (1 << 3);
+    }
 
     /// Reads PinB3  value.
     /// @return Port pin value.
-    static bool test()      { return PINB & (1<<3); }
+    static bool test() { return PINB & (1 << 3); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<3)
-    static constexpr uint8_t bitmask()               { return (1<<3); }
+    static constexpr uint8_t bitmask() { return (1 << 3); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 3
-    static constexpr uint8_t bit()                   { return 3; }
+    static constexpr uint8_t bit() { return 3; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortB;
@@ -309,39 +347,45 @@ struct PinB3 {
 
 struct PinB2 {
     /// Sets PinB2 to HIGH.
-    static void set()       { PORTB |= (1<<2); }
+    static void set() { PORTB |= (1 << 2); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinB2 to LOW.
-    static void clear()     { PORTB &= ~(1<<2); }
+    static void clear() { PORTB &= ~(1 << 2); }
 
     /// Toggles PinB2 value.
-    static void toggle()    { PINB |= (1<<2); }
+    static void toggle() { PINB |= (1 << 2); }
 
     /// Configures PinB2  as an output pin.
-    static void setOutput() { DDRB |= (1<<2); }
+    static void setOutput() { DDRB |= (1 << 2); }
 
     /// Configures PinB2  as an input pin.
-    static void setInput()  { DDRB &= ~(1<<2); }
+    static void setInput() { DDRB &= ~(1 << 2); }
 
     /// Pulses PinB2 with high state first.
-    static void pulseHigh() { PORTB |= (1<<2); PORTB &= ~(1<<2); }
+    static void pulseHigh() {
+        PORTB |= (1 << 2);
+        PORTB &= ~(1 << 2);
+    }
 
     /// Pulses PinB2 with low state first.
-    static void pulseLow()  { PORTB &= ~(1<<2); PORTB |= (1<<2); }
+    static void pulseLow() {
+        PORTB &= ~(1 << 2);
+        PORTB |= (1 << 2);
+    }
 
     /// Reads PinB2  value.
     /// @return Port pin value.
-    static bool test()      { return PINB & (1<<2); }
+    static bool test() { return PINB & (1 << 2); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<2)
-    static constexpr uint8_t bitmask()               { return (1<<2); }
+    static constexpr uint8_t bitmask() { return (1 << 2); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 2
-    static constexpr uint8_t bit()                   { return 2; }
+    static constexpr uint8_t bit() { return 2; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortB;
@@ -349,39 +393,45 @@ struct PinB2 {
 
 struct PinB1 {
     /// Sets PinB1 to HIGH.
-    static void set()       { PORTB |= (1<<1); }
+    static void set() { PORTB |= (1 << 1); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinB1 to LOW.
-    static void clear()     { PORTB &= ~(1<<1); }
+    static void clear() { PORTB &= ~(1 << 1); }
 
     /// Toggles PinB1 value.
-    static void toggle()    { PINB |= (1<<1); }
+    static void toggle() { PINB |= (1 << 1); }
 
     /// Configures PinB1  as an output pin.
-    static void setOutput() { DDRB |= (1<<1); }
+    static void setOutput() { DDRB |= (1 << 1); }
 
     /// Configures PinB1  as an input pin.
-    static void setInput()  { DDRB &= ~(1<<1); }
+    static void setInput() { DDRB &= ~(1 << 1); }
 
     /// Pulses PinB1 with high state first.
-    static void pulseHigh() { PORTB |= (1<<1); PORTB &= ~(1<<1); }
+    static void pulseHigh() {
+        PORTB |= (1 << 1);
+        PORTB &= ~(1 << 1);
+    }
 
     /// Pulses PinB1 with low state first.
-    static void pulseLow()  { PORTB &= ~(1<<1); PORTB |= (1<<1); }
+    static void pulseLow() {
+        PORTB &= ~(1 << 1);
+        PORTB |= (1 << 1);
+    }
 
     /// Reads PinB1  value.
     /// @return Port pin value.
-    static bool test()      { return PINB & (1<<1); }
+    static bool test() { return PINB & (1 << 1); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<1)
-    static constexpr uint8_t bitmask()               { return (1<<1); }
+    static constexpr uint8_t bitmask() { return (1 << 1); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 1
-    static constexpr uint8_t bit()                   { return 1; }
+    static constexpr uint8_t bit() { return 1; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortB;
@@ -389,135 +439,154 @@ struct PinB1 {
 
 struct PinB0 {
     /// Sets PinB0 to HIGH.
-    static void set()       { PORTB |= (1<<0); }
+    static void set() { PORTB |= (1 << 0); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinB0 to LOW.
-    static void clear()     { PORTB &= ~(1<<0); }
+    static void clear() { PORTB &= ~(1 << 0); }
 
     /// Toggles PinB0 value.
-    static void toggle()    { PINB |= (1<<0); }
+    static void toggle() { PINB |= (1 << 0); }
 
     /// Configures PinB0  as an output pin.
-    static void setOutput() { DDRB |= (1<<0); }
+    static void setOutput() { DDRB |= (1 << 0); }
 
     /// Configures PinB0  as an input pin.
-    static void setInput()  { DDRB &= ~(1<<0); }
+    static void setInput() { DDRB &= ~(1 << 0); }
 
     /// Pulses PinB0 with high state first.
-    static void pulseHigh() { PORTB |= (1<<0); PORTB &= ~(1<<0); }
+    static void pulseHigh() {
+        PORTB |= (1 << 0);
+        PORTB &= ~(1 << 0);
+    }
 
     /// Pulses PinB0 with low state first.
-    static void pulseLow()  { PORTB &= ~(1<<0); PORTB |= (1<<0); }
+    static void pulseLow() {
+        PORTB &= ~(1 << 0);
+        PORTB |= (1 << 0);
+    }
 
     /// Reads PinB0  value.
     /// @return Port pin value.
-    static bool test()      { return PINB & (1<<0); }
+    static bool test() { return PINB & (1 << 0); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<0)
-    static constexpr uint8_t bitmask()               { return (1<<0); }
+    static constexpr uint8_t bitmask() { return (1 << 0); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 0
-    static constexpr uint8_t bit()                   { return 0; }
+    static constexpr uint8_t bit() { return 0; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortB;
 };
-
 
 struct PortC {
     using PinChangeIRQ = PinChangeIRQ1;
 
     /// Assigns a value to PORTC
     /// @param[in] value value affected to PORTC
-    static void assign(uint8_t value)   { PORTC = value; }
+    static void assign(uint8_t value) { PORTC = value; }
 
     /// Sets masked bits in PORTC
     /// @param[in] mask bits to set
-    static void setBits(uint8_t mask)   { PORTC |= mask;}
+    static void setBits(uint8_t mask) { PORTC |= mask; }
 
     /// Clears masked bits in PORTC
     /// @param[in] mask bits to clear
-    static void clearBits(uint8_t mask) { PORTC &= ~mask;} 
+    static void clearBits(uint8_t mask) { PORTC &= ~mask; }
 
     /// Changes values of masked bits in PORTC
     /// @param[in] mask bits to change
     /// @param[in] value new bits values
-    static void changeBits(uint8_t mask, uint8_t value) { uint8_t tmp = PORTC & ~mask; PORTC = tmp | value; } 
+    static void changeBits(uint8_t mask, uint8_t value) {
+        uint8_t tmp = PORTC & ~mask;
+        PORTC = tmp | value;
+    }
 
     /// Toggles masked bits in PORTC
     /// @param[in] mask bits to toggle
-    static void toggleBits(uint8_t mask) { PORTC ^= mask;} 
+    static void toggleBits(uint8_t mask) { PORTC ^= mask; }
 
     /// Pulses masked bits in PORTC with high state first.
     /// @param[in] mask bits to pulse
-    static void pulseHigh(uint8_t mask) { PORTC |= mask; PORTC &= ~mask; }
+    static void pulseHigh(uint8_t mask) {
+        PORTC |= mask;
+        PORTC &= ~mask;
+    }
 
     /// Pulses masked bits in PORTC with low state first.
     /// @param[in] mask bits to pulse
-    static void pulseLow(uint8_t mask)  { PORTC &= ~mask; PORTC |= mask; }
+    static void pulseLow(uint8_t mask) {
+        PORTC &= ~mask;
+        PORTC |= mask;
+    }
 
     /// Set corresponding masked bits of PORTC to output direction.
     /// @param[in] mask bits
-    static void setOutput(uint8_t mask)    { DDRC |= mask; }
+    static void setOutput(uint8_t mask) { DDRC |= mask; }
 
     /// Set corresponding masked bits of PORTC to input direction.
     /// @param[in] mask bits
-    static void setInput(uint8_t mask)  { DDRC &= ~mask; }
+    static void setInput(uint8_t mask) { DDRC &= ~mask; }
 
     /// Returns PINC register.
-    static uint8_t getPIN()             { return PINC; }
+    static uint8_t getPIN() { return PINC; }
 
     /// Tests masked bits of PORTC
     /// @param[in] mask bits
     /// @param[in] true if the corresponding bits are all set, false otherwise.
-    static bool testBits(uint8_t mask)  { return (PINC & mask) == mask; }
+    static bool testBits(uint8_t mask) { return (PINC & mask) == mask; }
 
     /// Returns the value of the bit at the position pos.
     /// @param[in] position of the bit to return
     /// @return true if the requested bit is set, false otherwise.
-    static bool test(uint8_t pos) { return PINC & (1<<pos); }
-
+    static bool test(uint8_t pos) { return PINC & (1 << pos); }
 };
 
 struct PinC6 {
     /// Sets PinC6 to HIGH.
-    static void set()       { PORTC |= (1<<6); }
+    static void set() { PORTC |= (1 << 6); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinC6 to LOW.
-    static void clear()     { PORTC &= ~(1<<6); }
+    static void clear() { PORTC &= ~(1 << 6); }
 
     /// Toggles PinC6 value.
-    static void toggle()    { PINC |= (1<<6); }
+    static void toggle() { PINC |= (1 << 6); }
 
     /// Configures PinC6  as an output pin.
-    static void setOutput() { DDRC |= (1<<6); }
+    static void setOutput() { DDRC |= (1 << 6); }
 
     /// Configures PinC6  as an input pin.
-    static void setInput()  { DDRC &= ~(1<<6); }
+    static void setInput() { DDRC &= ~(1 << 6); }
 
     /// Pulses PinC6 with high state first.
-    static void pulseHigh() { PORTC |= (1<<6); PORTC &= ~(1<<6); }
+    static void pulseHigh() {
+        PORTC |= (1 << 6);
+        PORTC &= ~(1 << 6);
+    }
 
     /// Pulses PinC6 with low state first.
-    static void pulseLow()  { PORTC &= ~(1<<6); PORTC |= (1<<6); }
+    static void pulseLow() {
+        PORTC &= ~(1 << 6);
+        PORTC |= (1 << 6);
+    }
 
     /// Reads PinC6  value.
     /// @return Port pin value.
-    static bool test()      { return PINC & (1<<6); }
+    static bool test() { return PINC & (1 << 6); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<6)
-    static constexpr uint8_t bitmask()               { return (1<<6); }
+    static constexpr uint8_t bitmask() { return (1 << 6); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 6
-    static constexpr uint8_t bit()                   { return 6; }
+    static constexpr uint8_t bit() { return 6; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortC;
@@ -525,39 +594,45 @@ struct PinC6 {
 
 struct PinC5 {
     /// Sets PinC5 to HIGH.
-    static void set()       { PORTC |= (1<<5); }
+    static void set() { PORTC |= (1 << 5); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinC5 to LOW.
-    static void clear()     { PORTC &= ~(1<<5); }
+    static void clear() { PORTC &= ~(1 << 5); }
 
     /// Toggles PinC5 value.
-    static void toggle()    { PINC |= (1<<5); }
+    static void toggle() { PINC |= (1 << 5); }
 
     /// Configures PinC5  as an output pin.
-    static void setOutput() { DDRC |= (1<<5); }
+    static void setOutput() { DDRC |= (1 << 5); }
 
     /// Configures PinC5  as an input pin.
-    static void setInput()  { DDRC &= ~(1<<5); }
+    static void setInput() { DDRC &= ~(1 << 5); }
 
     /// Pulses PinC5 with high state first.
-    static void pulseHigh() { PORTC |= (1<<5); PORTC &= ~(1<<5); }
+    static void pulseHigh() {
+        PORTC |= (1 << 5);
+        PORTC &= ~(1 << 5);
+    }
 
     /// Pulses PinC5 with low state first.
-    static void pulseLow()  { PORTC &= ~(1<<5); PORTC |= (1<<5); }
+    static void pulseLow() {
+        PORTC &= ~(1 << 5);
+        PORTC |= (1 << 5);
+    }
 
     /// Reads PinC5  value.
     /// @return Port pin value.
-    static bool test()      { return PINC & (1<<5); }
+    static bool test() { return PINC & (1 << 5); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<5)
-    static constexpr uint8_t bitmask()               { return (1<<5); }
+    static constexpr uint8_t bitmask() { return (1 << 5); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 5
-    static constexpr uint8_t bit()                   { return 5; }
+    static constexpr uint8_t bit() { return 5; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortC;
@@ -565,39 +640,45 @@ struct PinC5 {
 
 struct PinC4 {
     /// Sets PinC4 to HIGH.
-    static void set()       { PORTC |= (1<<4); }
+    static void set() { PORTC |= (1 << 4); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinC4 to LOW.
-    static void clear()     { PORTC &= ~(1<<4); }
+    static void clear() { PORTC &= ~(1 << 4); }
 
     /// Toggles PinC4 value.
-    static void toggle()    { PINC |= (1<<4); }
+    static void toggle() { PINC |= (1 << 4); }
 
     /// Configures PinC4  as an output pin.
-    static void setOutput() { DDRC |= (1<<4); }
+    static void setOutput() { DDRC |= (1 << 4); }
 
     /// Configures PinC4  as an input pin.
-    static void setInput()  { DDRC &= ~(1<<4); }
+    static void setInput() { DDRC &= ~(1 << 4); }
 
     /// Pulses PinC4 with high state first.
-    static void pulseHigh() { PORTC |= (1<<4); PORTC &= ~(1<<4); }
+    static void pulseHigh() {
+        PORTC |= (1 << 4);
+        PORTC &= ~(1 << 4);
+    }
 
     /// Pulses PinC4 with low state first.
-    static void pulseLow()  { PORTC &= ~(1<<4); PORTC |= (1<<4); }
+    static void pulseLow() {
+        PORTC &= ~(1 << 4);
+        PORTC |= (1 << 4);
+    }
 
     /// Reads PinC4  value.
     /// @return Port pin value.
-    static bool test()      { return PINC & (1<<4); }
+    static bool test() { return PINC & (1 << 4); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<4)
-    static constexpr uint8_t bitmask()               { return (1<<4); }
+    static constexpr uint8_t bitmask() { return (1 << 4); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 4
-    static constexpr uint8_t bit()                   { return 4; }
+    static constexpr uint8_t bit() { return 4; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortC;
@@ -605,39 +686,45 @@ struct PinC4 {
 
 struct PinC3 {
     /// Sets PinC3 to HIGH.
-    static void set()       { PORTC |= (1<<3); }
+    static void set() { PORTC |= (1 << 3); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinC3 to LOW.
-    static void clear()     { PORTC &= ~(1<<3); }
+    static void clear() { PORTC &= ~(1 << 3); }
 
     /// Toggles PinC3 value.
-    static void toggle()    { PINC |= (1<<3); }
+    static void toggle() { PINC |= (1 << 3); }
 
     /// Configures PinC3  as an output pin.
-    static void setOutput() { DDRC |= (1<<3); }
+    static void setOutput() { DDRC |= (1 << 3); }
 
     /// Configures PinC3  as an input pin.
-    static void setInput()  { DDRC &= ~(1<<3); }
+    static void setInput() { DDRC &= ~(1 << 3); }
 
     /// Pulses PinC3 with high state first.
-    static void pulseHigh() { PORTC |= (1<<3); PORTC &= ~(1<<3); }
+    static void pulseHigh() {
+        PORTC |= (1 << 3);
+        PORTC &= ~(1 << 3);
+    }
 
     /// Pulses PinC3 with low state first.
-    static void pulseLow()  { PORTC &= ~(1<<3); PORTC |= (1<<3); }
+    static void pulseLow() {
+        PORTC &= ~(1 << 3);
+        PORTC |= (1 << 3);
+    }
 
     /// Reads PinC3  value.
     /// @return Port pin value.
-    static bool test()      { return PINC & (1<<3); }
+    static bool test() { return PINC & (1 << 3); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<3)
-    static constexpr uint8_t bitmask()               { return (1<<3); }
+    static constexpr uint8_t bitmask() { return (1 << 3); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 3
-    static constexpr uint8_t bit()                   { return 3; }
+    static constexpr uint8_t bit() { return 3; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortC;
@@ -645,39 +732,45 @@ struct PinC3 {
 
 struct PinC2 {
     /// Sets PinC2 to HIGH.
-    static void set()       { PORTC |= (1<<2); }
+    static void set() { PORTC |= (1 << 2); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinC2 to LOW.
-    static void clear()     { PORTC &= ~(1<<2); }
+    static void clear() { PORTC &= ~(1 << 2); }
 
     /// Toggles PinC2 value.
-    static void toggle()    { PINC |= (1<<2); }
+    static void toggle() { PINC |= (1 << 2); }
 
     /// Configures PinC2  as an output pin.
-    static void setOutput() { DDRC |= (1<<2); }
+    static void setOutput() { DDRC |= (1 << 2); }
 
     /// Configures PinC2  as an input pin.
-    static void setInput()  { DDRC &= ~(1<<2); }
+    static void setInput() { DDRC &= ~(1 << 2); }
 
     /// Pulses PinC2 with high state first.
-    static void pulseHigh() { PORTC |= (1<<2); PORTC &= ~(1<<2); }
+    static void pulseHigh() {
+        PORTC |= (1 << 2);
+        PORTC &= ~(1 << 2);
+    }
 
     /// Pulses PinC2 with low state first.
-    static void pulseLow()  { PORTC &= ~(1<<2); PORTC |= (1<<2); }
+    static void pulseLow() {
+        PORTC &= ~(1 << 2);
+        PORTC |= (1 << 2);
+    }
 
     /// Reads PinC2  value.
     /// @return Port pin value.
-    static bool test()      { return PINC & (1<<2); }
+    static bool test() { return PINC & (1 << 2); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<2)
-    static constexpr uint8_t bitmask()               { return (1<<2); }
+    static constexpr uint8_t bitmask() { return (1 << 2); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 2
-    static constexpr uint8_t bit()                   { return 2; }
+    static constexpr uint8_t bit() { return 2; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortC;
@@ -685,39 +778,45 @@ struct PinC2 {
 
 struct PinC1 {
     /// Sets PinC1 to HIGH.
-    static void set()       { PORTC |= (1<<1); }
+    static void set() { PORTC |= (1 << 1); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinC1 to LOW.
-    static void clear()     { PORTC &= ~(1<<1); }
+    static void clear() { PORTC &= ~(1 << 1); }
 
     /// Toggles PinC1 value.
-    static void toggle()    { PINC |= (1<<1); }
+    static void toggle() { PINC |= (1 << 1); }
 
     /// Configures PinC1  as an output pin.
-    static void setOutput() { DDRC |= (1<<1); }
+    static void setOutput() { DDRC |= (1 << 1); }
 
     /// Configures PinC1  as an input pin.
-    static void setInput()  { DDRC &= ~(1<<1); }
+    static void setInput() { DDRC &= ~(1 << 1); }
 
     /// Pulses PinC1 with high state first.
-    static void pulseHigh() { PORTC |= (1<<1); PORTC &= ~(1<<1); }
+    static void pulseHigh() {
+        PORTC |= (1 << 1);
+        PORTC &= ~(1 << 1);
+    }
 
     /// Pulses PinC1 with low state first.
-    static void pulseLow()  { PORTC &= ~(1<<1); PORTC |= (1<<1); }
+    static void pulseLow() {
+        PORTC &= ~(1 << 1);
+        PORTC |= (1 << 1);
+    }
 
     /// Reads PinC1  value.
     /// @return Port pin value.
-    static bool test()      { return PINC & (1<<1); }
+    static bool test() { return PINC & (1 << 1); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<1)
-    static constexpr uint8_t bitmask()               { return (1<<1); }
+    static constexpr uint8_t bitmask() { return (1 << 1); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 1
-    static constexpr uint8_t bit()                   { return 1; }
+    static constexpr uint8_t bit() { return 1; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortC;
@@ -725,135 +824,154 @@ struct PinC1 {
 
 struct PinC0 {
     /// Sets PinC0 to HIGH.
-    static void set()       { PORTC |= (1<<0); }
+    static void set() { PORTC |= (1 << 0); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinC0 to LOW.
-    static void clear()     { PORTC &= ~(1<<0); }
+    static void clear() { PORTC &= ~(1 << 0); }
 
     /// Toggles PinC0 value.
-    static void toggle()    { PINC |= (1<<0); }
+    static void toggle() { PINC |= (1 << 0); }
 
     /// Configures PinC0  as an output pin.
-    static void setOutput() { DDRC |= (1<<0); }
+    static void setOutput() { DDRC |= (1 << 0); }
 
     /// Configures PinC0  as an input pin.
-    static void setInput()  { DDRC &= ~(1<<0); }
+    static void setInput() { DDRC &= ~(1 << 0); }
 
     /// Pulses PinC0 with high state first.
-    static void pulseHigh() { PORTC |= (1<<0); PORTC &= ~(1<<0); }
+    static void pulseHigh() {
+        PORTC |= (1 << 0);
+        PORTC &= ~(1 << 0);
+    }
 
     /// Pulses PinC0 with low state first.
-    static void pulseLow()  { PORTC &= ~(1<<0); PORTC |= (1<<0); }
+    static void pulseLow() {
+        PORTC &= ~(1 << 0);
+        PORTC |= (1 << 0);
+    }
 
     /// Reads PinC0  value.
     /// @return Port pin value.
-    static bool test()      { return PINC & (1<<0); }
+    static bool test() { return PINC & (1 << 0); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<0)
-    static constexpr uint8_t bitmask()               { return (1<<0); }
+    static constexpr uint8_t bitmask() { return (1 << 0); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 0
-    static constexpr uint8_t bit()                   { return 0; }
+    static constexpr uint8_t bit() { return 0; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortC;
 };
-
 
 struct PortD {
     using PinChangeIRQ = PinChangeIRQ2;
 
     /// Assigns a value to PORTD
     /// @param[in] value value affected to PORTD
-    static void assign(uint8_t value)   { PORTD = value; }
+    static void assign(uint8_t value) { PORTD = value; }
 
     /// Sets masked bits in PORTD
     /// @param[in] mask bits to set
-    static void setBits(uint8_t mask)   { PORTD |= mask;}
+    static void setBits(uint8_t mask) { PORTD |= mask; }
 
     /// Clears masked bits in PORTD
     /// @param[in] mask bits to clear
-    static void clearBits(uint8_t mask) { PORTD &= ~mask;} 
+    static void clearBits(uint8_t mask) { PORTD &= ~mask; }
 
     /// Changes values of masked bits in PORTD
     /// @param[in] mask bits to change
     /// @param[in] value new bits values
-    static void changeBits(uint8_t mask, uint8_t value) { uint8_t tmp = PORTD & ~mask; PORTD = tmp | value; } 
+    static void changeBits(uint8_t mask, uint8_t value) {
+        uint8_t tmp = PORTD & ~mask;
+        PORTD = tmp | value;
+    }
 
     /// Toggles masked bits in PORTD
     /// @param[in] mask bits to toggle
-    static void toggleBits(uint8_t mask) { PORTD ^= mask;} 
+    static void toggleBits(uint8_t mask) { PORTD ^= mask; }
 
     /// Pulses masked bits in PORTD with high state first.
     /// @param[in] mask bits to pulse
-    static void pulseHigh(uint8_t mask) { PORTD |= mask; PORTD &= ~mask; }
+    static void pulseHigh(uint8_t mask) {
+        PORTD |= mask;
+        PORTD &= ~mask;
+    }
 
     /// Pulses masked bits in PORTD with low state first.
     /// @param[in] mask bits to pulse
-    static void pulseLow(uint8_t mask)  { PORTD &= ~mask; PORTD |= mask; }
+    static void pulseLow(uint8_t mask) {
+        PORTD &= ~mask;
+        PORTD |= mask;
+    }
 
     /// Set corresponding masked bits of PORTD to output direction.
     /// @param[in] mask bits
-    static void setOutput(uint8_t mask)    { DDRD |= mask; }
+    static void setOutput(uint8_t mask) { DDRD |= mask; }
 
     /// Set corresponding masked bits of PORTD to input direction.
     /// @param[in] mask bits
-    static void setInput(uint8_t mask)  { DDRD &= ~mask; }
+    static void setInput(uint8_t mask) { DDRD &= ~mask; }
 
     /// Returns PIND register.
-    static uint8_t getPIN()             { return PIND; }
+    static uint8_t getPIN() { return PIND; }
 
     /// Tests masked bits of PORTD
     /// @param[in] mask bits
     /// @param[in] true if the corresponding bits are all set, false otherwise.
-    static bool testBits(uint8_t mask)  { return (PIND & mask) == mask; }
+    static bool testBits(uint8_t mask) { return (PIND & mask) == mask; }
 
     /// Returns the value of the bit at the position pos.
     /// @param[in] position of the bit to return
     /// @return true if the requested bit is set, false otherwise.
-    static bool test(uint8_t pos) { return PIND & (1<<pos); }
-
+    static bool test(uint8_t pos) { return PIND & (1 << pos); }
 };
 
 struct PinD7 {
     /// Sets PinD7 to HIGH.
-    static void set()       { PORTD |= (1<<7); }
+    static void set() { PORTD |= (1 << 7); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinD7 to LOW.
-    static void clear()     { PORTD &= ~(1<<7); }
+    static void clear() { PORTD &= ~(1 << 7); }
 
     /// Toggles PinD7 value.
-    static void toggle()    { PIND |= (1<<7); }
+    static void toggle() { PIND |= (1 << 7); }
 
     /// Configures PinD7  as an output pin.
-    static void setOutput() { DDRD |= (1<<7); }
+    static void setOutput() { DDRD |= (1 << 7); }
 
     /// Configures PinD7  as an input pin.
-    static void setInput()  { DDRD &= ~(1<<7); }
+    static void setInput() { DDRD &= ~(1 << 7); }
 
     /// Pulses PinD7 with high state first.
-    static void pulseHigh() { PORTD |= (1<<7); PORTD &= ~(1<<7); }
+    static void pulseHigh() {
+        PORTD |= (1 << 7);
+        PORTD &= ~(1 << 7);
+    }
 
     /// Pulses PinD7 with low state first.
-    static void pulseLow()  { PORTD &= ~(1<<7); PORTD |= (1<<7); }
+    static void pulseLow() {
+        PORTD &= ~(1 << 7);
+        PORTD |= (1 << 7);
+    }
 
     /// Reads PinD7  value.
     /// @return Port pin value.
-    static bool test()      { return PIND & (1<<7); }
+    static bool test() { return PIND & (1 << 7); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<7)
-    static constexpr uint8_t bitmask()               { return (1<<7); }
+    static constexpr uint8_t bitmask() { return (1 << 7); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 7
-    static constexpr uint8_t bit()                   { return 7; }
+    static constexpr uint8_t bit() { return 7; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortD;
@@ -861,39 +979,45 @@ struct PinD7 {
 
 struct PinD6 {
     /// Sets PinD6 to HIGH.
-    static void set()       { PORTD |= (1<<6); }
+    static void set() { PORTD |= (1 << 6); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinD6 to LOW.
-    static void clear()     { PORTD &= ~(1<<6); }
+    static void clear() { PORTD &= ~(1 << 6); }
 
     /// Toggles PinD6 value.
-    static void toggle()    { PIND |= (1<<6); }
+    static void toggle() { PIND |= (1 << 6); }
 
     /// Configures PinD6  as an output pin.
-    static void setOutput() { DDRD |= (1<<6); }
+    static void setOutput() { DDRD |= (1 << 6); }
 
     /// Configures PinD6  as an input pin.
-    static void setInput()  { DDRD &= ~(1<<6); }
+    static void setInput() { DDRD &= ~(1 << 6); }
 
     /// Pulses PinD6 with high state first.
-    static void pulseHigh() { PORTD |= (1<<6); PORTD &= ~(1<<6); }
+    static void pulseHigh() {
+        PORTD |= (1 << 6);
+        PORTD &= ~(1 << 6);
+    }
 
     /// Pulses PinD6 with low state first.
-    static void pulseLow()  { PORTD &= ~(1<<6); PORTD |= (1<<6); }
+    static void pulseLow() {
+        PORTD &= ~(1 << 6);
+        PORTD |= (1 << 6);
+    }
 
     /// Reads PinD6  value.
     /// @return Port pin value.
-    static bool test()      { return PIND & (1<<6); }
+    static bool test() { return PIND & (1 << 6); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<6)
-    static constexpr uint8_t bitmask()               { return (1<<6); }
+    static constexpr uint8_t bitmask() { return (1 << 6); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 6
-    static constexpr uint8_t bit()                   { return 6; }
+    static constexpr uint8_t bit() { return 6; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortD;
@@ -901,39 +1025,45 @@ struct PinD6 {
 
 struct PinD5 {
     /// Sets PinD5 to HIGH.
-    static void set()       { PORTD |= (1<<5); }
+    static void set() { PORTD |= (1 << 5); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinD5 to LOW.
-    static void clear()     { PORTD &= ~(1<<5); }
+    static void clear() { PORTD &= ~(1 << 5); }
 
     /// Toggles PinD5 value.
-    static void toggle()    { PIND |= (1<<5); }
+    static void toggle() { PIND |= (1 << 5); }
 
     /// Configures PinD5  as an output pin.
-    static void setOutput() { DDRD |= (1<<5); }
+    static void setOutput() { DDRD |= (1 << 5); }
 
     /// Configures PinD5  as an input pin.
-    static void setInput()  { DDRD &= ~(1<<5); }
+    static void setInput() { DDRD &= ~(1 << 5); }
 
     /// Pulses PinD5 with high state first.
-    static void pulseHigh() { PORTD |= (1<<5); PORTD &= ~(1<<5); }
+    static void pulseHigh() {
+        PORTD |= (1 << 5);
+        PORTD &= ~(1 << 5);
+    }
 
     /// Pulses PinD5 with low state first.
-    static void pulseLow()  { PORTD &= ~(1<<5); PORTD |= (1<<5); }
+    static void pulseLow() {
+        PORTD &= ~(1 << 5);
+        PORTD |= (1 << 5);
+    }
 
     /// Reads PinD5  value.
     /// @return Port pin value.
-    static bool test()      { return PIND & (1<<5); }
+    static bool test() { return PIND & (1 << 5); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<5)
-    static constexpr uint8_t bitmask()               { return (1<<5); }
+    static constexpr uint8_t bitmask() { return (1 << 5); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 5
-    static constexpr uint8_t bit()                   { return 5; }
+    static constexpr uint8_t bit() { return 5; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortD;
@@ -941,39 +1071,45 @@ struct PinD5 {
 
 struct PinD4 {
     /// Sets PinD4 to HIGH.
-    static void set()       { PORTD |= (1<<4); }
+    static void set() { PORTD |= (1 << 4); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinD4 to LOW.
-    static void clear()     { PORTD &= ~(1<<4); }
+    static void clear() { PORTD &= ~(1 << 4); }
 
     /// Toggles PinD4 value.
-    static void toggle()    { PIND |= (1<<4); }
+    static void toggle() { PIND |= (1 << 4); }
 
     /// Configures PinD4  as an output pin.
-    static void setOutput() { DDRD |= (1<<4); }
+    static void setOutput() { DDRD |= (1 << 4); }
 
     /// Configures PinD4  as an input pin.
-    static void setInput()  { DDRD &= ~(1<<4); }
+    static void setInput() { DDRD &= ~(1 << 4); }
 
     /// Pulses PinD4 with high state first.
-    static void pulseHigh() { PORTD |= (1<<4); PORTD &= ~(1<<4); }
+    static void pulseHigh() {
+        PORTD |= (1 << 4);
+        PORTD &= ~(1 << 4);
+    }
 
     /// Pulses PinD4 with low state first.
-    static void pulseLow()  { PORTD &= ~(1<<4); PORTD |= (1<<4); }
+    static void pulseLow() {
+        PORTD &= ~(1 << 4);
+        PORTD |= (1 << 4);
+    }
 
     /// Reads PinD4  value.
     /// @return Port pin value.
-    static bool test()      { return PIND & (1<<4); }
+    static bool test() { return PIND & (1 << 4); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<4)
-    static constexpr uint8_t bitmask()               { return (1<<4); }
+    static constexpr uint8_t bitmask() { return (1 << 4); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 4
-    static constexpr uint8_t bit()                   { return 4; }
+    static constexpr uint8_t bit() { return 4; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortD;
@@ -981,39 +1117,45 @@ struct PinD4 {
 
 struct PinD3 {
     /// Sets PinD3 to HIGH.
-    static void set()       { PORTD |= (1<<3); }
+    static void set() { PORTD |= (1 << 3); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinD3 to LOW.
-    static void clear()     { PORTD &= ~(1<<3); }
+    static void clear() { PORTD &= ~(1 << 3); }
 
     /// Toggles PinD3 value.
-    static void toggle()    { PIND |= (1<<3); }
+    static void toggle() { PIND |= (1 << 3); }
 
     /// Configures PinD3  as an output pin.
-    static void setOutput() { DDRD |= (1<<3); }
+    static void setOutput() { DDRD |= (1 << 3); }
 
     /// Configures PinD3  as an input pin.
-    static void setInput()  { DDRD &= ~(1<<3); }
+    static void setInput() { DDRD &= ~(1 << 3); }
 
     /// Pulses PinD3 with high state first.
-    static void pulseHigh() { PORTD |= (1<<3); PORTD &= ~(1<<3); }
+    static void pulseHigh() {
+        PORTD |= (1 << 3);
+        PORTD &= ~(1 << 3);
+    }
 
     /// Pulses PinD3 with low state first.
-    static void pulseLow()  { PORTD &= ~(1<<3); PORTD |= (1<<3); }
+    static void pulseLow() {
+        PORTD &= ~(1 << 3);
+        PORTD |= (1 << 3);
+    }
 
     /// Reads PinD3  value.
     /// @return Port pin value.
-    static bool test()      { return PIND & (1<<3); }
+    static bool test() { return PIND & (1 << 3); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<3)
-    static constexpr uint8_t bitmask()               { return (1<<3); }
+    static constexpr uint8_t bitmask() { return (1 << 3); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 3
-    static constexpr uint8_t bit()                   { return 3; }
+    static constexpr uint8_t bit() { return 3; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortD;
@@ -1021,39 +1163,45 @@ struct PinD3 {
 
 struct PinD2 {
     /// Sets PinD2 to HIGH.
-    static void set()       { PORTD |= (1<<2); }
+    static void set() { PORTD |= (1 << 2); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinD2 to LOW.
-    static void clear()     { PORTD &= ~(1<<2); }
+    static void clear() { PORTD &= ~(1 << 2); }
 
     /// Toggles PinD2 value.
-    static void toggle()    { PIND |= (1<<2); }
+    static void toggle() { PIND |= (1 << 2); }
 
     /// Configures PinD2  as an output pin.
-    static void setOutput() { DDRD |= (1<<2); }
+    static void setOutput() { DDRD |= (1 << 2); }
 
     /// Configures PinD2  as an input pin.
-    static void setInput()  { DDRD &= ~(1<<2); }
+    static void setInput() { DDRD &= ~(1 << 2); }
 
     /// Pulses PinD2 with high state first.
-    static void pulseHigh() { PORTD |= (1<<2); PORTD &= ~(1<<2); }
+    static void pulseHigh() {
+        PORTD |= (1 << 2);
+        PORTD &= ~(1 << 2);
+    }
 
     /// Pulses PinD2 with low state first.
-    static void pulseLow()  { PORTD &= ~(1<<2); PORTD |= (1<<2); }
+    static void pulseLow() {
+        PORTD &= ~(1 << 2);
+        PORTD |= (1 << 2);
+    }
 
     /// Reads PinD2  value.
     /// @return Port pin value.
-    static bool test()      { return PIND & (1<<2); }
+    static bool test() { return PIND & (1 << 2); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<2)
-    static constexpr uint8_t bitmask()               { return (1<<2); }
+    static constexpr uint8_t bitmask() { return (1 << 2); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 2
-    static constexpr uint8_t bit()                   { return 2; }
+    static constexpr uint8_t bit() { return 2; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortD;
@@ -1061,39 +1209,45 @@ struct PinD2 {
 
 struct PinD1 {
     /// Sets PinD1 to HIGH.
-    static void set()       { PORTD |= (1<<1); }
+    static void set() { PORTD |= (1 << 1); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinD1 to LOW.
-    static void clear()     { PORTD &= ~(1<<1); }
+    static void clear() { PORTD &= ~(1 << 1); }
 
     /// Toggles PinD1 value.
-    static void toggle()    { PIND |= (1<<1); }
+    static void toggle() { PIND |= (1 << 1); }
 
     /// Configures PinD1  as an output pin.
-    static void setOutput() { DDRD |= (1<<1); }
+    static void setOutput() { DDRD |= (1 << 1); }
 
     /// Configures PinD1  as an input pin.
-    static void setInput()  { DDRD &= ~(1<<1); }
+    static void setInput() { DDRD &= ~(1 << 1); }
 
     /// Pulses PinD1 with high state first.
-    static void pulseHigh() { PORTD |= (1<<1); PORTD &= ~(1<<1); }
+    static void pulseHigh() {
+        PORTD |= (1 << 1);
+        PORTD &= ~(1 << 1);
+    }
 
     /// Pulses PinD1 with low state first.
-    static void pulseLow()  { PORTD &= ~(1<<1); PORTD |= (1<<1); }
+    static void pulseLow() {
+        PORTD &= ~(1 << 1);
+        PORTD |= (1 << 1);
+    }
 
     /// Reads PinD1  value.
     /// @return Port pin value.
-    static bool test()      { return PIND & (1<<1); }
+    static bool test() { return PIND & (1 << 1); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<1)
-    static constexpr uint8_t bitmask()               { return (1<<1); }
+    static constexpr uint8_t bitmask() { return (1 << 1); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 1
-    static constexpr uint8_t bit()                   { return 1; }
+    static constexpr uint8_t bit() { return 1; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortD;
@@ -1101,305 +1255,364 @@ struct PinD1 {
 
 struct PinD0 {
     /// Sets PinD0 to HIGH.
-    static void set()       { PORTD |= (1<<0); }
+    static void set() { PORTD |= (1 << 0); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinD0 to LOW.
-    static void clear()     { PORTD &= ~(1<<0); }
+    static void clear() { PORTD &= ~(1 << 0); }
 
     /// Toggles PinD0 value.
-    static void toggle()    { PIND |= (1<<0); }
+    static void toggle() { PIND |= (1 << 0); }
 
     /// Configures PinD0  as an output pin.
-    static void setOutput() { DDRD |= (1<<0); }
+    static void setOutput() { DDRD |= (1 << 0); }
 
     /// Configures PinD0  as an input pin.
-    static void setInput()  { DDRD &= ~(1<<0); }
+    static void setInput() { DDRD &= ~(1 << 0); }
 
     /// Pulses PinD0 with high state first.
-    static void pulseHigh() { PORTD |= (1<<0); PORTD &= ~(1<<0); }
+    static void pulseHigh() {
+        PORTD |= (1 << 0);
+        PORTD &= ~(1 << 0);
+    }
 
     /// Pulses PinD0 with low state first.
-    static void pulseLow()  { PORTD &= ~(1<<0); PORTD |= (1<<0); }
+    static void pulseLow() {
+        PORTD &= ~(1 << 0);
+        PORTD |= (1 << 0);
+    }
 
     /// Reads PinD0  value.
     /// @return Port pin value.
-    static bool test()      { return PIND & (1<<0); }
+    static bool test() { return PIND & (1 << 0); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<0)
-    static constexpr uint8_t bitmask()               { return (1<<0); }
+    static constexpr uint8_t bitmask() { return (1 << 0); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 0
-    static constexpr uint8_t bit()                   { return 0; }
+    static constexpr uint8_t bit() { return 0; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortD;
 };
 
-
 struct SpiSpcr {
 
-  /// Assigns a value to SPCR
-  /// @param[in] value value affected to SPCR
-  static void Assign(uint8_t value)  { SPCR = value; }
+    /// Assigns a value to SPCR
+    /// @param[in] value value affected to SPCR
+    static void Assign(uint8_t value) { SPCR = value; }
 
-  /// Sets masked bits in SPCR
-  /// @param[in] mask bits to set
-  static void Set(uint8_t mask)      { SPCR |= mask; }
+    /// Sets masked bits in SPCR
+    /// @param[in] mask bits to set
+    static void Set(uint8_t mask) { SPCR |= mask; }
 
-  /// Clears masked bits in SPCR
-  /// @param[in] mask bits to clear
-  static void Clear(uint8_t mask)    { SPCR &= ~mask; }
-  static uint8_t Get()               { return SPCR; }
-  static bool TestBits(uint8_t mask) { return SPCR & mask; }
-  void operator=(uint8_t value)      { SPCR = value; }
+    /// Clears masked bits in SPCR
+    /// @param[in] mask bits to clear
+    static void Clear(uint8_t mask) { SPCR &= ~mask; }
+    static uint8_t Get() { return SPCR; }
+    static bool TestBits(uint8_t mask) { return SPCR & mask; }
+    void operator=(uint8_t value) { SPCR = value; }
 };
 
 struct SpiSpdr {
 
-  /// Assigns a value to SPDR
-  /// @param[in] value value affected to SPDR
-  static void Assign(uint8_t value)  { SPDR = value; }
+    /// Assigns a value to SPDR
+    /// @param[in] value value affected to SPDR
+    static void Assign(uint8_t value) { SPDR = value; }
 
-  /// Sets masked bits in SPDR
-  /// @param[in] mask bits to set
-  static void Set(uint8_t mask)      { SPDR |= mask; }
+    /// Sets masked bits in SPDR
+    /// @param[in] mask bits to set
+    static void Set(uint8_t mask) { SPDR |= mask; }
 
-  /// Clears masked bits in SPDR
-  /// @param[in] mask bits to clear
-  static void Clear(uint8_t mask)    { SPDR &= ~mask; }
-  static uint8_t Get()               { return SPDR; }
-  static bool TestBits(uint8_t mask) { return SPDR & mask; }
-  void operator=(uint8_t value)      { SPDR = value; }
+    /// Clears masked bits in SPDR
+    /// @param[in] mask bits to clear
+    static void Clear(uint8_t mask) { SPDR &= ~mask; }
+    static uint8_t Get() { return SPDR; }
+    static bool TestBits(uint8_t mask) { return SPDR & mask; }
+    void operator=(uint8_t value) { SPDR = value; }
 };
 
 struct SpiSpsr {
 
-  /// Assigns a value to SPSR
-  /// @param[in] value value affected to SPSR
-  static void Assign(uint8_t value)  { SPSR = value; }
+    /// Assigns a value to SPSR
+    /// @param[in] value value affected to SPSR
+    static void Assign(uint8_t value) { SPSR = value; }
 
-  /// Sets masked bits in SPSR
-  /// @param[in] mask bits to set
-  static void Set(uint8_t mask)      { SPSR |= mask; }
+    /// Sets masked bits in SPSR
+    /// @param[in] mask bits to set
+    static void Set(uint8_t mask) { SPSR |= mask; }
 
-  /// Clears masked bits in SPSR
-  /// @param[in] mask bits to clear
-  static void Clear(uint8_t mask)    { SPSR &= ~mask; }
-  static uint8_t Get()               { return SPSR; }
-  static bool TestBits(uint8_t mask) { return SPSR & mask; }
-  void operator=(uint8_t value)      { SPSR = value; }
+    /// Clears masked bits in SPSR
+    /// @param[in] mask bits to clear
+    static void Clear(uint8_t mask) { SPSR &= ~mask; }
+    static uint8_t Get() { return SPSR; }
+    static bool TestBits(uint8_t mask) { return SPSR & mask; }
+    void operator=(uint8_t value) { SPSR = value; }
 };
 
 struct Timer0 {
-  using value_type = uint8_t;
-  static const uint8_t timer_width = 8;
+    using value_type = uint8_t;
+    static const uint8_t timer_width = 8;
 
-  enum Prescaler : uint8_t {
-    STOP_TIMER = 0, NO_PRESCALER = (1<<CS00), CLK_DIV_8 = (1<<CS01),
-    CLK_DIV_32 = (1<<CS01)|(1<<CS00), CLK_DIV_64 = (1<<CS02),
-    CLK_DIV_128 = (1<<CS02)|(1<<CS00), CLK_DIV_256 = (1<<CS02)|(1<<CS01),
-    CLK_DIV_1024 = (1<<CS02)|(1<<CS01)|(1<<CS00), BITS = (1<<CS02)|(1<<CS01)|(1<<CS00) };
+    enum Prescaler : uint8_t {
+        STOP_TIMER = 0,
+        NO_PRESCALER = (1 << CS00),
+        CLK_DIV_8 = (1 << CS01),
+        CLK_DIV_32 = (1 << CS01) | (1 << CS00),
+        CLK_DIV_64 = (1 << CS02),
+        CLK_DIV_128 = (1 << CS02) | (1 << CS00),
+        CLK_DIV_256 = (1 << CS02) | (1 << CS01),
+        CLK_DIV_1024 = (1 << CS02) | (1 << CS01) | (1 << CS00),
+        BITS = (1 << CS02) | (1 << CS01) | (1 << CS00)
+    };
 
-  enum Interrupt : uint8_t { 
-    OVERFLOW = (1<<TOIE0), COMPARE_MATCH_A = (1<<OCIE0A), COMPARE_MATCH_B = (1<<OCIE0B)};
-  enum Constants : uint8_t { ALL_BITS = 0xFF };
-  static value_type getValue()                 { return TCNT0; }
-  static void setValue(value_type value)       { TCNT0 = value; }
-  static void addValue(value_type value)       { TCNT0 += value; }
-  static void subValue(value_type value)       { TCNT0 -= value; }
-  static void setCtrlRegA(uint8_t mask)        { TCCR0A |= mask; }
-  static void clearCtrlRegA(uint8_t mask)      { TCCR0A &= ~mask; }
-  static void setCtrlRegB(uint8_t mask)        { TCCR0B |= mask; }
-  static void clearCtrlRegB(uint8_t mask)      { TCCR0B &= ~mask; }
-  static void setInterruptMask(uint8_t mask)   { TIMSK0 |= mask; }
-  static void clearInterruptMask(uint8_t mask) { TIMSK0 &= ~mask; }
-  static void setPrescaler(Prescaler val)      { TCCR0B &= ~Prescaler::BITS; TCCR0B |= val; }
-  static void setOutputCompareValueA(value_type value) { OCR0A = value; }
-  static value_type getOutputCompareValueA()           { return OCR0A; }
-  static void setOutputCompareValueB(value_type value) { OCR0B = value; }
-  static value_type getOutputCompareValueB()           { return OCR0B; }
+    enum Interrupt : uint8_t { OVERFLOW = (1 << TOIE0), COMPARE_MATCH_A = (1 << OCIE0A), COMPARE_MATCH_B = (1 << OCIE0B) };
+    enum Constants : uint8_t { ALL_BITS = 0xFF };
+    static value_type getValue() { return TCNT0; }
+    static void setValue(value_type value) { TCNT0 = value; }
+    static void addValue(value_type value) { TCNT0 += value; }
+    static void subValue(value_type value) { TCNT0 -= value; }
+    static void setCtrlRegA(uint8_t mask) { TCCR0A |= mask; }
+    static void clearCtrlRegA(uint8_t mask) { TCCR0A &= ~mask; }
+    static void setCtrlRegB(uint8_t mask) { TCCR0B |= mask; }
+    static void clearCtrlRegB(uint8_t mask) { TCCR0B &= ~mask; }
+    static void setInterruptMask(uint8_t mask) { TIMSK0 |= mask; }
+    static void clearInterruptMask(uint8_t mask) { TIMSK0 &= ~mask; }
+    static void setPrescaler(Prescaler val) {
+        TCCR0B &= ~Prescaler::BITS;
+        TCCR0B |= val;
+    }
+    static void setOutputCompareValueA(value_type value) { OCR0A = value; }
+    static value_type getOutputCompareValueA() { return OCR0A; }
+    static void setOutputCompareValueB(value_type value) { OCR0B = value; }
+    static value_type getOutputCompareValueB() { return OCR0B; }
 
-  struct Isr {
-    static void Overflow() IOPORTS_IRQ_HANDLER(TIMER0_OVF_vect, signal);
-    static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER0_COMPA_vect, signal);
-    static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER0_COMPB_vect, signal);
-  };
+    struct Isr {
+        static void Overflow() IOPORTS_IRQ_HANDLER(TIMER0_OVF_vect, signal);
+        static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER0_COMPA_vect, signal);
+        static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER0_COMPB_vect, signal);
+    };
 
-  struct IsrNoBlock {
-    static void Overflow() IOPORTS_IRQ_HANDLER(TIMER0_OVF_vect, interrupt);
-    static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER0_COMPA_vect, interrupt);
-    static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER0_COMPB_vect, interrupt);
-  };
+    struct IsrNoBlock {
+        static void Overflow() IOPORTS_IRQ_HANDLER(TIMER0_OVF_vect, interrupt);
+        static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER0_COMPA_vect, interrupt);
+        static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER0_COMPB_vect, interrupt);
+    };
 
-  struct IsrNaked {
-    static void Overflow() IOPORTS_IRQ_HANDLER(TIMER0_OVF_vect, naked);
-    static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER0_COMPA_vect, naked);
-    static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER0_COMPB_vect, naked);
-  };
-};  
-
-struct Timer1 {
-  using value_type = uint16_t;
-  static const uint8_t timer_width = 16;
-
-  enum Prescaler : uint8_t {
-    STOP_TIMER = 0, NO_PRESCALER = (1<<CS10), CLK_DIV_8 = (1<<CS11),
-    CLK_DIV_32 = (1<<CS11)|(1<<CS10), CLK_DIV_64 = (1<<CS12),
-    CLK_DIV_128 = (1<<CS12)|(1<<CS10), CLK_DIV_256 = (1<<CS12)|(1<<CS11),
-    CLK_DIV_1024 = (1<<CS12)|(1<<CS11)|(1<<CS10), BITS = (1<<CS12)|(1<<CS11)|(1<<CS10) };
-
-  enum Interrupt : uint8_t { 
-    OVERFLOW = (1<<TOIE1), CAPTURE = (1<<ICIE1), COMPARE_MATCH_A = (1<<OCIE1A), COMPARE_MATCH_B = (1<<OCIE1B)};
-  enum Constants : uint8_t { ALL_BITS = 0xFF };
-  static value_type getValue()                 { return TCNT1; }
-  static void setValue(value_type value)       { TCNT1 = value; }
-  static void addValue(value_type value)       { TCNT1 += value; }
-  static void subValue(value_type value)       { TCNT1 -= value; }
-  static void setCtrlRegA(uint8_t mask)        { TCCR1A |= mask; }
-  static void clearCtrlRegA(uint8_t mask)      { TCCR1A &= ~mask; }
-  static void setCtrlRegB(uint8_t mask)        { TCCR1B |= mask; }
-  static void clearCtrlRegB(uint8_t mask)      { TCCR1B &= ~mask; }
-  static void setInterruptMask(uint8_t mask)   { TIMSK1 |= mask; }
-  static void clearInterruptMask(uint8_t mask) { TIMSK1 &= ~mask; }
-  static void setPrescaler(Prescaler val)      { TCCR1B &= ~Prescaler::BITS; TCCR1B |= val; }
-  static void setOutputCompareValueA(value_type value) { OCR1A = value; }
-  static value_type getOutputCompareValueA()           { return OCR1A; }
-  static void setOutputCompareValueB(value_type value) { OCR1B = value; }
-  static value_type getOutputCompareValueB()           { return OCR1B; }
-
-  struct Isr {
-    static void Overflow() IOPORTS_IRQ_HANDLER(TIMER1_OVF_vect, signal);
-    static void Capture() IOPORTS_IRQ_HANDLER(TIMER1_CAPT_vect, signal);
-    static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER1_COMPA_vect, signal);
-    static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER1_COMPB_vect, signal);
-  };
-
-  struct IsrNoBlock {
-    static void Overflow() IOPORTS_IRQ_HANDLER(TIMER1_OVF_vect, interrupt);
-    static void Capture() IOPORTS_IRQ_HANDLER(TIMER1_CAPT_vect, interrupt);
-    static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER1_COMPA_vect, interrupt);
-    static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER1_COMPB_vect, interrupt);
-  };
-
-  struct IsrNaked {
-    static void Overflow() IOPORTS_IRQ_HANDLER(TIMER1_OVF_vect, naked);
-    static void Capture() IOPORTS_IRQ_HANDLER(TIMER1_CAPT_vect, naked);
-    static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER1_COMPA_vect, naked);
-    static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER1_COMPB_vect, naked);
-  };
-};  
-
-struct Timer2 {
-  using value_type = uint8_t;
-  static const uint8_t timer_width = 8;
-
-  enum Prescaler : uint8_t {
-    STOP_TIMER = 0, NO_PRESCALER = (1<<CS20), CLK_DIV_8 = (1<<CS21),
-    CLK_DIV_64 = (1<<CS21)|(1<<CS20), CLK_DIV_256 = (1<<CS22),
-    CLK_DIV_1024 = (1<<CS22)|(1<<CS20), BITS = (1<<CS22)|(1<<CS21)|(1<<CS20) };
-  enum ClockSource : uint8_t {
-    INC_ON_FALLING = (1<<CS22)|(1<<CS21), INC_ON_RISING = (1<<CS22)|(1<<CS21)|(1<<CS20) };
-
-  enum Interrupt : uint8_t { 
-    OVERFLOW = (1<<TOIE2), COMPARE_MATCH_A = (1<<OCIE2A), COMPARE_MATCH_B = (1<<OCIE2B)};
-  enum Constants : uint8_t { ALL_BITS = 0xFF };
-  static value_type getValue()                 { return TCNT2; }
-  static void setValue(value_type value)       { TCNT2 = value; }
-  static void addValue(value_type value)       { TCNT2 += value; }
-  static void subValue(value_type value)       { TCNT2 -= value; }
-  static void setCtrlRegA(uint8_t mask)        { TCCR2A |= mask; }
-  static void clearCtrlRegA(uint8_t mask)      { TCCR2A &= ~mask; }
-  static void setCtrlRegB(uint8_t mask)        { TCCR2B |= mask; }
-  static void clearCtrlRegB(uint8_t mask)      { TCCR2B &= ~mask; }
-  static void setInterruptMask(uint8_t mask)   { TIMSK2 |= mask; }
-  static void clearInterruptMask(uint8_t mask) { TIMSK2 &= ~mask; }
-  static void setPrescaler(Prescaler val)      { TCCR2B &= ~Prescaler::BITS; TCCR2B |= val; }
-  static void setExternalClockSource(ClockSource val)  { TCCR2B &= ~Prescaler::BITS; TCCR2B |= val; }
-  static void setOutputCompareValueA(value_type value) { OCR2A = value; }
-  static value_type getOutputCompareValueA()           { return OCR2A; }
-  static void setOutputCompareValueB(value_type value) { OCR2B = value; }
-  static value_type getOutputCompareValueB()           { return OCR2B; }
-
-  struct Isr {
-    static void Overflow() IOPORTS_IRQ_HANDLER(TIMER2_OVF_vect, signal);
-    static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER2_COMPA_vect, signal);
-    static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER2_COMPB_vect, signal);
-  };
-
-  struct IsrNoBlock {
-    static void Overflow() IOPORTS_IRQ_HANDLER(TIMER2_OVF_vect, interrupt);
-    static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER2_COMPA_vect, interrupt);
-    static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER2_COMPB_vect, interrupt);
-  };
-
-  struct IsrNaked {
-    static void Overflow() IOPORTS_IRQ_HANDLER(TIMER2_OVF_vect, naked);
-    static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER2_COMPA_vect, naked);
-    static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER2_COMPB_vect, naked);
-  };
-};  
-
-template<typename> struct is_uart_txd_capable : std::false_type {};
-template<typename> struct is_uart_rxd_capable : std::false_type {};
-enum FrameFormat {
-    _5N1 = 0b00000, _5N2 = 0b000001, _5E1 = 0b00010, _5E2 = 0b00011, _5O1 = 0b00100, _5O2 = 0b00101,       // Encoding 5-N-1 : nbBits - no, even or odd parity - 1 or 2 stop bits : 0b00 - 00 - 0
-    _6N1 = 0b01000, _6N2 = 0b010001, _6E1 = 0b01010, _6E2 = 0b01011, _6O1 = 0b01100, _6O2 = 0b01101,
-    _7N1 = 0b10000, _7N2 = 0b100001, _7E1 = 0b10010, _7E2 = 0b10011, _7O1 = 0b10100, _7O2 = 0b10101,
-    _8N1 = 0b11000, _8N2 = 0b110001, _8E1 = 0b11010, _8E2 = 0b11011, _8O1 = 0b11100, _8O2 = 0b11101,
-    NbBitsMask = 0b11000, ParityMask = 0b00110, StopBitMask = 0b00001
+    struct IsrNaked {
+        static void Overflow() IOPORTS_IRQ_HANDLER(TIMER0_OVF_vect, naked);
+        static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER0_COMPA_vect, naked);
+        static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER0_COMPB_vect, naked);
+    };
 };
 
-template<> struct is_uart_rxd_capable<PinD0> : std::true_type {};
-template<> struct is_uart_txd_capable<PinD1> : std::true_type {};
+struct Timer1 {
+    using value_type = uint16_t;
+    static const uint8_t timer_width = 16;
+
+    enum Prescaler : uint8_t {
+        STOP_TIMER = 0,
+        NO_PRESCALER = (1 << CS10),
+        CLK_DIV_8 = (1 << CS11),
+        CLK_DIV_32 = (1 << CS11) | (1 << CS10),
+        CLK_DIV_64 = (1 << CS12),
+        CLK_DIV_128 = (1 << CS12) | (1 << CS10),
+        CLK_DIV_256 = (1 << CS12) | (1 << CS11),
+        CLK_DIV_1024 = (1 << CS12) | (1 << CS11) | (1 << CS10),
+        BITS = (1 << CS12) | (1 << CS11) | (1 << CS10)
+    };
+
+    enum Interrupt : uint8_t {
+        OVERFLOW = (1 << TOIE1),
+        CAPTURE = (1 << ICIE1),
+        COMPARE_MATCH_A = (1 << OCIE1A),
+        COMPARE_MATCH_B = (1 << OCIE1B)
+    };
+    enum Constants : uint8_t { ALL_BITS = 0xFF };
+    static value_type getValue() { return TCNT1; }
+    static void setValue(value_type value) { TCNT1 = value; }
+    static void addValue(value_type value) { TCNT1 += value; }
+    static void subValue(value_type value) { TCNT1 -= value; }
+    static void setCtrlRegA(uint8_t mask) { TCCR1A |= mask; }
+    static void clearCtrlRegA(uint8_t mask) { TCCR1A &= ~mask; }
+    static void setCtrlRegB(uint8_t mask) { TCCR1B |= mask; }
+    static void clearCtrlRegB(uint8_t mask) { TCCR1B &= ~mask; }
+    static void setInterruptMask(uint8_t mask) { TIMSK1 |= mask; }
+    static void clearInterruptMask(uint8_t mask) { TIMSK1 &= ~mask; }
+    static void setPrescaler(Prescaler val) {
+        TCCR1B &= ~Prescaler::BITS;
+        TCCR1B |= val;
+    }
+    static void setOutputCompareValueA(value_type value) { OCR1A = value; }
+    static value_type getOutputCompareValueA() { return OCR1A; }
+    static void setOutputCompareValueB(value_type value) { OCR1B = value; }
+    static value_type getOutputCompareValueB() { return OCR1B; }
+
+    struct Isr {
+        static void Overflow() IOPORTS_IRQ_HANDLER(TIMER1_OVF_vect, signal);
+        static void Capture() IOPORTS_IRQ_HANDLER(TIMER1_CAPT_vect, signal);
+        static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER1_COMPA_vect, signal);
+        static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER1_COMPB_vect, signal);
+    };
+
+    struct IsrNoBlock {
+        static void Overflow() IOPORTS_IRQ_HANDLER(TIMER1_OVF_vect, interrupt);
+        static void Capture() IOPORTS_IRQ_HANDLER(TIMER1_CAPT_vect, interrupt);
+        static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER1_COMPA_vect, interrupt);
+        static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER1_COMPB_vect, interrupt);
+    };
+
+    struct IsrNaked {
+        static void Overflow() IOPORTS_IRQ_HANDLER(TIMER1_OVF_vect, naked);
+        static void Capture() IOPORTS_IRQ_HANDLER(TIMER1_CAPT_vect, naked);
+        static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER1_COMPA_vect, naked);
+        static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER1_COMPB_vect, naked);
+    };
+};
+
+struct Timer2 {
+    using value_type = uint8_t;
+    static const uint8_t timer_width = 8;
+
+    enum Prescaler : uint8_t {
+        STOP_TIMER = 0,
+        NO_PRESCALER = (1 << CS20),
+        CLK_DIV_8 = (1 << CS21),
+        CLK_DIV_64 = (1 << CS21) | (1 << CS20),
+        CLK_DIV_256 = (1 << CS22),
+        CLK_DIV_1024 = (1 << CS22) | (1 << CS20),
+        BITS = (1 << CS22) | (1 << CS21) | (1 << CS20)
+    };
+    enum ClockSource : uint8_t {
+        INC_ON_FALLING = (1 << CS22) | (1 << CS21),
+        INC_ON_RISING = (1 << CS22) | (1 << CS21) | (1 << CS20)
+    };
+
+    enum Interrupt : uint8_t { OVERFLOW = (1 << TOIE2), COMPARE_MATCH_A = (1 << OCIE2A), COMPARE_MATCH_B = (1 << OCIE2B) };
+    enum Constants : uint8_t { ALL_BITS = 0xFF };
+    static value_type getValue() { return TCNT2; }
+    static void setValue(value_type value) { TCNT2 = value; }
+    static void addValue(value_type value) { TCNT2 += value; }
+    static void subValue(value_type value) { TCNT2 -= value; }
+    static void setCtrlRegA(uint8_t mask) { TCCR2A |= mask; }
+    static void clearCtrlRegA(uint8_t mask) { TCCR2A &= ~mask; }
+    static void setCtrlRegB(uint8_t mask) { TCCR2B |= mask; }
+    static void clearCtrlRegB(uint8_t mask) { TCCR2B &= ~mask; }
+    static void setInterruptMask(uint8_t mask) { TIMSK2 |= mask; }
+    static void clearInterruptMask(uint8_t mask) { TIMSK2 &= ~mask; }
+    static void setPrescaler(Prescaler val) {
+        TCCR2B &= ~Prescaler::BITS;
+        TCCR2B |= val;
+    }
+    static void setExternalClockSource(ClockSource val) {
+        TCCR2B &= ~Prescaler::BITS;
+        TCCR2B |= val;
+    }
+    static void setOutputCompareValueA(value_type value) { OCR2A = value; }
+    static value_type getOutputCompareValueA() { return OCR2A; }
+    static void setOutputCompareValueB(value_type value) { OCR2B = value; }
+    static value_type getOutputCompareValueB() { return OCR2B; }
+
+    struct Isr {
+        static void Overflow() IOPORTS_IRQ_HANDLER(TIMER2_OVF_vect, signal);
+        static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER2_COMPA_vect, signal);
+        static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER2_COMPB_vect, signal);
+    };
+
+    struct IsrNoBlock {
+        static void Overflow() IOPORTS_IRQ_HANDLER(TIMER2_OVF_vect, interrupt);
+        static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER2_COMPA_vect, interrupt);
+        static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER2_COMPB_vect, interrupt);
+    };
+
+    struct IsrNaked {
+        static void Overflow() IOPORTS_IRQ_HANDLER(TIMER2_OVF_vect, naked);
+        static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER2_COMPA_vect, naked);
+        static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER2_COMPB_vect, naked);
+    };
+};
+
+template <typename> struct is_uart_txd_capable : ETLSTD::false_type {};
+template <typename> struct is_uart_rxd_capable : ETLSTD::false_type {};
+enum FrameFormat {
+    _5N1 = 0b00000,
+    _5N2 = 0b000001,
+    _5E1 = 0b00010,
+    _5E2 = 0b00011,
+    _5O1 = 0b00100,
+    _5O2 = 0b00101, // Encoding 5-N-1 : nbBits - no, even or odd parity - 1 or 2 stop bits : 0b00 - 00 - 0
+    _6N1 = 0b01000,
+    _6N2 = 0b010001,
+    _6E1 = 0b01010,
+    _6E2 = 0b01011,
+    _6O1 = 0b01100,
+    _6O2 = 0b01101,
+    _7N1 = 0b10000,
+    _7N2 = 0b100001,
+    _7E1 = 0b10010,
+    _7E2 = 0b10011,
+    _7O1 = 0b10100,
+    _7O2 = 0b10101,
+    _8N1 = 0b11000,
+    _8N2 = 0b110001,
+    _8E1 = 0b11010,
+    _8E2 = 0b11011,
+    _8O1 = 0b11100,
+    _8O2 = 0b11101,
+    NbBitsMask = 0b11000,
+    ParityMask = 0b00110,
+    StopBitMask = 0b00001
+};
+
+template <> struct is_uart_rxd_capable<PinD0> : ETLSTD::true_type {};
+template <> struct is_uart_txd_capable<PinD1> : ETLSTD::true_type {};
 
 class Uart0Driver {
     static const uint8_t BufferSize = 32;
     static uint8_t readIndex, writeIndex;
+
 protected:
     static void start(uint32_t BAUD_RATE, FrameFormat FRAME_FORMAT) {
         readIndex = 0;
         writeIndex = 0;
         float speedRate = BAUD_RATE > 57600 ? BAUD_RATE * 8 : BAUD_RATE * 16;
         auto spd = static_cast<uint16_t>(((Device::McuFrequency / speedRate)) - 0.5);
-        UBRR0H = spd>>8 &0b1111;
+        UBRR0H = spd >> 8 & 0b1111;
         UBRR0L = spd;
-        
+
         auto nbBits = (FRAME_FORMAT & FrameFormat::NbBitsMask) >> 3;
         auto nbBits1 = (nbBits & 0b10) == 0b10;
         auto nbBits0 = (nbBits & 0b1) == 0b1;
-        
+
         auto parityMode = (FRAME_FORMAT & FrameFormat::ParityMask) >> 1;
         auto parity0 = parityMode == 0b10;
         auto parity1 = parityMode != 0b00;
-         
-        auto stopBit = (FRAME_FORMAT & FrameFormat::StopBitMask) >> 0;
-        
-        if (BAUD_RATE > 57600)
-            UCSR0A = 1<<U2X0;
-        UCSR0C = (nbBits1<<UCSZ01) | (nbBits0<<UCSZ00) | (parity0<<UPM00) | (parity1<<UPM01) | (stopBit<<USBS0);
-        UCSR0B = (1<<RXEN0) | (1<<TXEN0) | (1<<RXCIE0);
-     }
 
-    using Queue =  etl::CircularBuffer<uint8_t,BufferSize>;
+        auto stopBit = (FRAME_FORMAT & FrameFormat::StopBitMask) >> 0;
+
+        if (BAUD_RATE > 57600)
+            UCSR0A = 1 << U2X0;
+        UCSR0C = (nbBits1 << UCSZ01) | (nbBits0 << UCSZ00) | (parity0 << UPM00) | (parity1 << UPM01) | (stopBit << USBS0);
+        UCSR0B = (1 << RXEN0) | (1 << TXEN0) | (1 << RXCIE0);
+    }
+
+    using Queue = etl::CircularBuffer<uint8_t, BufferSize>;
     static Queue fifo;
-    using ReceiveCallback = void(*)(uint8_t);
+    using ReceiveCallback = void (*)(uint8_t);
     static ReceiveCallback receiveCallback;
 
 public:
     static void writeAsync(uint8_t datum) {
-        if (UCSR0A & (1<<UDRE0)) {
+        if (UCSR0A & (1 << UDRE0)) {
             UDR0 = datum;
-        }
-        else {
+        } else {
             fifo.push_back(datum);
-            UCSR0B |= 1<<UDRIE0;
+            UCSR0B |= 1 << UDRIE0;
         }
     }
-
 
     struct Isr {
         static void receiveComplete() IOPORTS_IRQ_HANDLER(USART0_RX_vect, signal);
@@ -1413,14 +1626,14 @@ Uart0Driver::Queue Uart0Driver::fifo;
 Uart0Driver::ReceiveCallback Uart0Driver::receiveCallback = nullptr;
 
 void Uart0Driver::Isr::fifoEmpty() {
-      if (!fifo.empty()) {
-        while((UCSR0A & (1<<UDRE0)) && !fifo.empty()) {
-            UDR0 =  fifo.pop_front();
-         }
-       } else {
-        UCSR0B &= ~(1<<UDRIE0);
-       }
-  }
+    if (!fifo.empty()) {
+        while ((UCSR0A & (1 << UDRE0)) && !fifo.empty()) {
+            UDR0 = fifo.pop_front();
+        }
+    } else {
+        UCSR0B &= ~(1 << UDRIE0);
+    }
+}
 
 void Uart0Driver::Isr::receiveComplete() {
     if (receiveCallback) {
@@ -1428,139 +1641,135 @@ void Uart0Driver::Isr::receiveComplete() {
     }
 }
 
-template<uint32_t BAUD_RATE, FrameFormat FRAME_FORMAT, typename CharType>
-class Uart0 : public Uart0Driver {
+template <uint32_t BAUD_RATE, FrameFormat FRAME_FORMAT, typename CharType> class Uart0 : public Uart0Driver {
 public:
-    using ReceiveCallback = void(*)(CharType);
+    using ReceiveCallback = void (*)(CharType);
     enum class StatusFlags : uint8_t {
-        ReceiveComplete = 1<<RXC0,
-        TransmitComplete = 1<<TXC0,
-        FrameError = 1<<FE0,
-        DataOverrun = 1<<DOR0,
-        ParityError = 1<<UPE0,
+        ReceiveComplete = 1 << RXC0,
+        TransmitComplete = 1 << TXC0,
+        FrameError = 1 << FE0,
+        DataOverrun = 1 << DOR0,
+        ParityError = 1 << UPE0,
     };
-    
+
     static void start() { Uart0Driver::start(BAUD_RATE, FRAME_FORMAT); }
     static void start(ReceiveCallback func) {
         receiveCallback = static_cast<Uart0Driver::ReceiveCallback>(func);
         start();
     }
-    
+
     static void write(CharType datum) {
-        while(fifo.size() >= (BufferSize-1)) {
-            Device::delayTicks(Device::McuFrequency/(BAUD_RATE/8));
+        while (fifo.size() >= (BufferSize - 1)) {
+            Device::delayTicks(Device::McuFrequency / (BAUD_RATE / 8));
         }
         writeAsync(datum);
     }
 };
 
-template<> struct is_uart_rxd_capable<PinD2> : std::true_type {};
-template<> struct is_uart_txd_capable<PinD3> : std::true_type {};
+template <> struct is_uart_rxd_capable<PinD2> : ETLSTD::true_type {};
+template <> struct is_uart_txd_capable<PinD3> : ETLSTD::true_type {};
 
 #ifdef PCICR
 struct PinChangeControlRegister {
-  static void setBits(uint8_t mask)   { PCICR |= mask; }
-  static void clearBits(uint8_t mask) { PCICR &= ~mask; }
+    static void setBits(uint8_t mask) { PCICR |= mask; }
+    static void clearBits(uint8_t mask) { PCICR &= ~mask; }
 };
 #endif // PCICR
 
 struct PinChangeMask0 {
-  static void setBits(uint8_t mask)   { PCMSK0 |= mask; }
-  static void clearBits(uint8_t mask) { PCMSK0 &= ~mask; }
-  static uint8_t Get()                { return PCMSK0; }
+    static void setBits(uint8_t mask) { PCMSK0 |= mask; }
+    static void clearBits(uint8_t mask) { PCMSK0 &= ~mask; }
+    static uint8_t Get() { return PCMSK0; }
 };
 
 struct PinChangeIRQ0 {
-  static void enableSource(uint8_t PCINT) {
-    PinChangeControlRegister::setBits(1<<PCIE0);
-    PinChangeMask0::setBits(1<<PCINT);
-  }
-
-  static void disableSource(uint8_t PCINT) {
-    PinChangeMask0::clearBits(1<<PCINT);
-    if (0 == PinChangeMask0::Get()) {
-      PinChangeControlRegister::clearBits(1<<PCIE0);
+    static void enableSource(uint8_t PCINT) {
+        PinChangeControlRegister::setBits(1 << PCIE0);
+        PinChangeMask0::setBits(1 << PCINT);
     }
-  }
 
-  struct Isr {
-    static void trigger() IOPORTS_IRQ_HANDLER(PCINT0_vect, signal);
-  };
+    static void disableSource(uint8_t PCINT) {
+        PinChangeMask0::clearBits(1 << PCINT);
+        if (0 == PinChangeMask0::Get()) {
+            PinChangeControlRegister::clearBits(1 << PCIE0);
+        }
+    }
 
-  struct IsrNoBlock {
-    static void trigger() IOPORTS_IRQ_HANDLER(PCINT0_vect, interrupt);
-  };
+    struct Isr {
+        static void trigger() IOPORTS_IRQ_HANDLER(PCINT0_vect, signal);
+    };
 
-  struct IsrNaked {
-    static void trigger() IOPORTS_IRQ_HANDLER(PCINT0_vect, naked);
-  };
+    struct IsrNoBlock {
+        static void trigger() IOPORTS_IRQ_HANDLER(PCINT0_vect, interrupt);
+    };
 
+    struct IsrNaked {
+        static void trigger() IOPORTS_IRQ_HANDLER(PCINT0_vect, naked);
+    };
 };
 
 struct PinChangeMask1 {
-  static void setBits(uint8_t mask)   { PCMSK1 |= mask; }
-  static void clearBits(uint8_t mask) { PCMSK1 &= ~mask; }
-  static uint8_t Get()                { return PCMSK1; }
+    static void setBits(uint8_t mask) { PCMSK1 |= mask; }
+    static void clearBits(uint8_t mask) { PCMSK1 &= ~mask; }
+    static uint8_t Get() { return PCMSK1; }
 };
 
 struct PinChangeIRQ1 {
-  static void enableSource(uint8_t PCINT) {
-    PinChangeControlRegister::setBits(1<<PCIE1);
-    PinChangeMask1::setBits(1<<PCINT);
-  }
-
-  static void disableSource(uint8_t PCINT) {
-    PinChangeMask1::clearBits(1<<PCINT);
-    if (0 == PinChangeMask1::Get()) {
-      PinChangeControlRegister::clearBits(1<<PCIE1);
+    static void enableSource(uint8_t PCINT) {
+        PinChangeControlRegister::setBits(1 << PCIE1);
+        PinChangeMask1::setBits(1 << PCINT);
     }
-  }
 
-  struct Isr {
-    static void trigger() IOPORTS_IRQ_HANDLER(PCINT1_vect, signal);
-  };
+    static void disableSource(uint8_t PCINT) {
+        PinChangeMask1::clearBits(1 << PCINT);
+        if (0 == PinChangeMask1::Get()) {
+            PinChangeControlRegister::clearBits(1 << PCIE1);
+        }
+    }
 
-  struct IsrNoBlock {
-    static void trigger() IOPORTS_IRQ_HANDLER(PCINT1_vect, interrupt);
-  };
+    struct Isr {
+        static void trigger() IOPORTS_IRQ_HANDLER(PCINT1_vect, signal);
+    };
 
-  struct IsrNaked {
-    static void trigger() IOPORTS_IRQ_HANDLER(PCINT1_vect, naked);
-  };
+    struct IsrNoBlock {
+        static void trigger() IOPORTS_IRQ_HANDLER(PCINT1_vect, interrupt);
+    };
 
+    struct IsrNaked {
+        static void trigger() IOPORTS_IRQ_HANDLER(PCINT1_vect, naked);
+    };
 };
 
 struct PinChangeMask2 {
-  static void setBits(uint8_t mask)   { PCMSK2 |= mask; }
-  static void clearBits(uint8_t mask) { PCMSK2 &= ~mask; }
-  static uint8_t Get()                { return PCMSK2; }
+    static void setBits(uint8_t mask) { PCMSK2 |= mask; }
+    static void clearBits(uint8_t mask) { PCMSK2 &= ~mask; }
+    static uint8_t Get() { return PCMSK2; }
 };
 
 struct PinChangeIRQ2 {
-  static void enableSource(uint8_t PCINT) {
-    PinChangeControlRegister::setBits(1<<PCIE2);
-    PinChangeMask2::setBits(1<<PCINT);
-  }
-
-  static void disableSource(uint8_t PCINT) {
-    PinChangeMask2::clearBits(1<<PCINT);
-    if (0 == PinChangeMask2::Get()) {
-      PinChangeControlRegister::clearBits(1<<PCIE2);
+    static void enableSource(uint8_t PCINT) {
+        PinChangeControlRegister::setBits(1 << PCIE2);
+        PinChangeMask2::setBits(1 << PCINT);
     }
-  }
 
-  struct Isr {
-    static void trigger() IOPORTS_IRQ_HANDLER(PCINT2_vect, signal);
-  };
+    static void disableSource(uint8_t PCINT) {
+        PinChangeMask2::clearBits(1 << PCINT);
+        if (0 == PinChangeMask2::Get()) {
+            PinChangeControlRegister::clearBits(1 << PCIE2);
+        }
+    }
 
-  struct IsrNoBlock {
-    static void trigger() IOPORTS_IRQ_HANDLER(PCINT2_vect, interrupt);
-  };
+    struct Isr {
+        static void trigger() IOPORTS_IRQ_HANDLER(PCINT2_vect, signal);
+    };
 
-  struct IsrNaked {
-    static void trigger() IOPORTS_IRQ_HANDLER(PCINT2_vect, naked);
-  };
+    struct IsrNoBlock {
+        static void trigger() IOPORTS_IRQ_HANDLER(PCINT2_vect, interrupt);
+    };
 
+    struct IsrNaked {
+        static void trigger() IOPORTS_IRQ_HANDLER(PCINT2_vect, naked);
+    };
 };
 
 #undef IOPORTS_TO_STRING

--- a/include/etl/architecture/ioports_ATtiny84.h
+++ b/include/etl/architecture/ioports_ATtiny84.h
@@ -19,7 +19,7 @@
 //     contributors may be used to endorse or promote products derived
 //     from this software without specific prior written permission.
 //
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' 
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
 //  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 //  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 //  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
@@ -32,112 +32,126 @@
 //  POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <util/delay.h>
-#include <avr/io.h>
+#include "ETLDevice_ATtiny84.h"
 #include <avr/interrupt.h>
+#include <avr/io.h>
+#include <etl/CircularBuffer.h>
 #include <libstd/include/chrono>
 #include <libstd/include/queue>
-#include <etl/CircularBuffer.h>
-#include "ETLDevice_ATtiny84.h"
+#include <util/delay.h>
 
 extern void __builtin_avr_delay_cycles(unsigned long);
 
 namespace etl {
 #define IOPORTS_TO_STRING(name) #name
-#define IOPORTS_IRQ_HANDLER(vector, type) asm(IOPORTS_TO_STRING(vector)) __attribute__ ((type, __INTR_ATTRS))
+#define IOPORTS_IRQ_HANDLER(vector, type) asm(IOPORTS_TO_STRING(vector)) __attribute__((type, __INTR_ATTRS))
 
-using clock_cycles = std::chrono::duration<unsigned long, std::ratio<1, Device::McuFrequency>>;
-constexpr clock_cycles operator ""_clks(unsigned long long c)     { return clock_cycles(static_cast<clock_cycles::rep>(c)); }
+using clock_cycles = ETLSTD::chrono::duration<unsigned long, ETLSTD::ratio<1, Device::McuFrequency>>;
+constexpr clock_cycles operator""_clks(unsigned long long c) { return clock_cycles(static_cast<clock_cycles::rep>(c)); }
 
 struct PortA {
 
     /// Assigns a value to PORTA
     /// @param[in] value value affected to PORTA
-    static void assign(uint8_t value)   { PORTA = value; }
+    static void assign(uint8_t value) { PORTA = value; }
 
     /// Sets masked bits in PORTA
     /// @param[in] mask bits to set
-    static void setBits(uint8_t mask)   { PORTA |= mask;}
+    static void setBits(uint8_t mask) { PORTA |= mask; }
 
     /// Clears masked bits in PORTA
     /// @param[in] mask bits to clear
-    static void clearBits(uint8_t mask) { PORTA &= ~mask;} 
+    static void clearBits(uint8_t mask) { PORTA &= ~mask; }
 
     /// Changes values of masked bits in PORTA
     /// @param[in] mask bits to change
     /// @param[in] value new bits values
-    static void changeBits(uint8_t mask, uint8_t value) { uint8_t tmp = PORTA & ~mask; PORTA = tmp | value; } 
+    static void changeBits(uint8_t mask, uint8_t value) {
+        uint8_t tmp = PORTA & ~mask;
+        PORTA = tmp | value;
+    }
 
     /// Toggles masked bits in PORTA
     /// @param[in] mask bits to toggle
-    static void toggleBits(uint8_t mask) { PORTA ^= mask;} 
+    static void toggleBits(uint8_t mask) { PORTA ^= mask; }
 
     /// Pulses masked bits in PORTA with high state first.
     /// @param[in] mask bits to pulse
-    static void pulseHigh(uint8_t mask) { PORTA |= mask; PORTA &= ~mask; }
+    static void pulseHigh(uint8_t mask) {
+        PORTA |= mask;
+        PORTA &= ~mask;
+    }
 
     /// Pulses masked bits in PORTA with low state first.
     /// @param[in] mask bits to pulse
-    static void pulseLow(uint8_t mask)  { PORTA &= ~mask; PORTA |= mask; }
+    static void pulseLow(uint8_t mask) {
+        PORTA &= ~mask;
+        PORTA |= mask;
+    }
 
     /// Set corresponding masked bits of PORTA to output direction.
     /// @param[in] mask bits
-    static void setOutput(uint8_t mask)    { DDRA |= mask; }
+    static void setOutput(uint8_t mask) { DDRA |= mask; }
 
     /// Set corresponding masked bits of PORTA to input direction.
     /// @param[in] mask bits
-    static void setInput(uint8_t mask)  { DDRA &= ~mask; }
+    static void setInput(uint8_t mask) { DDRA &= ~mask; }
 
     /// Returns PINA register.
-    static uint8_t getPIN()             { return PINA; }
+    static uint8_t getPIN() { return PINA; }
 
     /// Tests masked bits of PORTA
     /// @param[in] mask bits
     /// @param[in] true if the corresponding bits are all set, false otherwise.
-    static bool testBits(uint8_t mask)  { return (PINA & mask) == mask; }
+    static bool testBits(uint8_t mask) { return (PINA & mask) == mask; }
 
     /// Returns the value of the bit at the position pos.
     /// @param[in] position of the bit to return
     /// @return true if the requested bit is set, false otherwise.
-    static bool test(uint8_t pos) { return PINA & (1<<pos); }
-
+    static bool test(uint8_t pos) { return PINA & (1 << pos); }
 };
 
 struct PinA7 {
     /// Sets PinA7 to HIGH.
-    static void set()       { PORTA |= (1<<7); }
+    static void set() { PORTA |= (1 << 7); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinA7 to LOW.
-    static void clear()     { PORTA &= ~(1<<7); }
+    static void clear() { PORTA &= ~(1 << 7); }
 
     /// Toggles PinA7 value.
-    static void toggle()    { PINA |= (1<<7); }
+    static void toggle() { PINA |= (1 << 7); }
 
     /// Configures PinA7  as an output pin.
-    static void setOutput() { DDRA |= (1<<7); }
+    static void setOutput() { DDRA |= (1 << 7); }
 
     /// Configures PinA7  as an input pin.
-    static void setInput()  { DDRA &= ~(1<<7); }
+    static void setInput() { DDRA &= ~(1 << 7); }
 
     /// Pulses PinA7 with high state first.
-    static void pulseHigh() { PORTA |= (1<<7); PORTA &= ~(1<<7); }
+    static void pulseHigh() {
+        PORTA |= (1 << 7);
+        PORTA &= ~(1 << 7);
+    }
 
     /// Pulses PinA7 with low state first.
-    static void pulseLow()  { PORTA &= ~(1<<7); PORTA |= (1<<7); }
+    static void pulseLow() {
+        PORTA &= ~(1 << 7);
+        PORTA |= (1 << 7);
+    }
 
     /// Reads PinA7  value.
     /// @return Port pin value.
-    static bool test()      { return PINA & (1<<7); }
+    static bool test() { return PINA & (1 << 7); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<7)
-    static constexpr uint8_t bitmask()               { return (1<<7); }
+    static constexpr uint8_t bitmask() { return (1 << 7); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 7
-    static constexpr uint8_t bit()                   { return 7; }
+    static constexpr uint8_t bit() { return 7; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortA;
@@ -145,39 +159,45 @@ struct PinA7 {
 
 struct PinA6 {
     /// Sets PinA6 to HIGH.
-    static void set()       { PORTA |= (1<<6); }
+    static void set() { PORTA |= (1 << 6); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinA6 to LOW.
-    static void clear()     { PORTA &= ~(1<<6); }
+    static void clear() { PORTA &= ~(1 << 6); }
 
     /// Toggles PinA6 value.
-    static void toggle()    { PINA |= (1<<6); }
+    static void toggle() { PINA |= (1 << 6); }
 
     /// Configures PinA6  as an output pin.
-    static void setOutput() { DDRA |= (1<<6); }
+    static void setOutput() { DDRA |= (1 << 6); }
 
     /// Configures PinA6  as an input pin.
-    static void setInput()  { DDRA &= ~(1<<6); }
+    static void setInput() { DDRA &= ~(1 << 6); }
 
     /// Pulses PinA6 with high state first.
-    static void pulseHigh() { PORTA |= (1<<6); PORTA &= ~(1<<6); }
+    static void pulseHigh() {
+        PORTA |= (1 << 6);
+        PORTA &= ~(1 << 6);
+    }
 
     /// Pulses PinA6 with low state first.
-    static void pulseLow()  { PORTA &= ~(1<<6); PORTA |= (1<<6); }
+    static void pulseLow() {
+        PORTA &= ~(1 << 6);
+        PORTA |= (1 << 6);
+    }
 
     /// Reads PinA6  value.
     /// @return Port pin value.
-    static bool test()      { return PINA & (1<<6); }
+    static bool test() { return PINA & (1 << 6); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<6)
-    static constexpr uint8_t bitmask()               { return (1<<6); }
+    static constexpr uint8_t bitmask() { return (1 << 6); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 6
-    static constexpr uint8_t bit()                   { return 6; }
+    static constexpr uint8_t bit() { return 6; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortA;
@@ -185,39 +205,45 @@ struct PinA6 {
 
 struct PinA5 {
     /// Sets PinA5 to HIGH.
-    static void set()       { PORTA |= (1<<5); }
+    static void set() { PORTA |= (1 << 5); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinA5 to LOW.
-    static void clear()     { PORTA &= ~(1<<5); }
+    static void clear() { PORTA &= ~(1 << 5); }
 
     /// Toggles PinA5 value.
-    static void toggle()    { PINA |= (1<<5); }
+    static void toggle() { PINA |= (1 << 5); }
 
     /// Configures PinA5  as an output pin.
-    static void setOutput() { DDRA |= (1<<5); }
+    static void setOutput() { DDRA |= (1 << 5); }
 
     /// Configures PinA5  as an input pin.
-    static void setInput()  { DDRA &= ~(1<<5); }
+    static void setInput() { DDRA &= ~(1 << 5); }
 
     /// Pulses PinA5 with high state first.
-    static void pulseHigh() { PORTA |= (1<<5); PORTA &= ~(1<<5); }
+    static void pulseHigh() {
+        PORTA |= (1 << 5);
+        PORTA &= ~(1 << 5);
+    }
 
     /// Pulses PinA5 with low state first.
-    static void pulseLow()  { PORTA &= ~(1<<5); PORTA |= (1<<5); }
+    static void pulseLow() {
+        PORTA &= ~(1 << 5);
+        PORTA |= (1 << 5);
+    }
 
     /// Reads PinA5  value.
     /// @return Port pin value.
-    static bool test()      { return PINA & (1<<5); }
+    static bool test() { return PINA & (1 << 5); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<5)
-    static constexpr uint8_t bitmask()               { return (1<<5); }
+    static constexpr uint8_t bitmask() { return (1 << 5); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 5
-    static constexpr uint8_t bit()                   { return 5; }
+    static constexpr uint8_t bit() { return 5; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortA;
@@ -225,39 +251,45 @@ struct PinA5 {
 
 struct PinA4 {
     /// Sets PinA4 to HIGH.
-    static void set()       { PORTA |= (1<<4); }
+    static void set() { PORTA |= (1 << 4); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinA4 to LOW.
-    static void clear()     { PORTA &= ~(1<<4); }
+    static void clear() { PORTA &= ~(1 << 4); }
 
     /// Toggles PinA4 value.
-    static void toggle()    { PINA |= (1<<4); }
+    static void toggle() { PINA |= (1 << 4); }
 
     /// Configures PinA4  as an output pin.
-    static void setOutput() { DDRA |= (1<<4); }
+    static void setOutput() { DDRA |= (1 << 4); }
 
     /// Configures PinA4  as an input pin.
-    static void setInput()  { DDRA &= ~(1<<4); }
+    static void setInput() { DDRA &= ~(1 << 4); }
 
     /// Pulses PinA4 with high state first.
-    static void pulseHigh() { PORTA |= (1<<4); PORTA &= ~(1<<4); }
+    static void pulseHigh() {
+        PORTA |= (1 << 4);
+        PORTA &= ~(1 << 4);
+    }
 
     /// Pulses PinA4 with low state first.
-    static void pulseLow()  { PORTA &= ~(1<<4); PORTA |= (1<<4); }
+    static void pulseLow() {
+        PORTA &= ~(1 << 4);
+        PORTA |= (1 << 4);
+    }
 
     /// Reads PinA4  value.
     /// @return Port pin value.
-    static bool test()      { return PINA & (1<<4); }
+    static bool test() { return PINA & (1 << 4); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<4)
-    static constexpr uint8_t bitmask()               { return (1<<4); }
+    static constexpr uint8_t bitmask() { return (1 << 4); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 4
-    static constexpr uint8_t bit()                   { return 4; }
+    static constexpr uint8_t bit() { return 4; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortA;
@@ -265,39 +297,45 @@ struct PinA4 {
 
 struct PinA3 {
     /// Sets PinA3 to HIGH.
-    static void set()       { PORTA |= (1<<3); }
+    static void set() { PORTA |= (1 << 3); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinA3 to LOW.
-    static void clear()     { PORTA &= ~(1<<3); }
+    static void clear() { PORTA &= ~(1 << 3); }
 
     /// Toggles PinA3 value.
-    static void toggle()    { PINA |= (1<<3); }
+    static void toggle() { PINA |= (1 << 3); }
 
     /// Configures PinA3  as an output pin.
-    static void setOutput() { DDRA |= (1<<3); }
+    static void setOutput() { DDRA |= (1 << 3); }
 
     /// Configures PinA3  as an input pin.
-    static void setInput()  { DDRA &= ~(1<<3); }
+    static void setInput() { DDRA &= ~(1 << 3); }
 
     /// Pulses PinA3 with high state first.
-    static void pulseHigh() { PORTA |= (1<<3); PORTA &= ~(1<<3); }
+    static void pulseHigh() {
+        PORTA |= (1 << 3);
+        PORTA &= ~(1 << 3);
+    }
 
     /// Pulses PinA3 with low state first.
-    static void pulseLow()  { PORTA &= ~(1<<3); PORTA |= (1<<3); }
+    static void pulseLow() {
+        PORTA &= ~(1 << 3);
+        PORTA |= (1 << 3);
+    }
 
     /// Reads PinA3  value.
     /// @return Port pin value.
-    static bool test()      { return PINA & (1<<3); }
+    static bool test() { return PINA & (1 << 3); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<3)
-    static constexpr uint8_t bitmask()               { return (1<<3); }
+    static constexpr uint8_t bitmask() { return (1 << 3); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 3
-    static constexpr uint8_t bit()                   { return 3; }
+    static constexpr uint8_t bit() { return 3; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortA;
@@ -305,39 +343,45 @@ struct PinA3 {
 
 struct PinA2 {
     /// Sets PinA2 to HIGH.
-    static void set()       { PORTA |= (1<<2); }
+    static void set() { PORTA |= (1 << 2); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinA2 to LOW.
-    static void clear()     { PORTA &= ~(1<<2); }
+    static void clear() { PORTA &= ~(1 << 2); }
 
     /// Toggles PinA2 value.
-    static void toggle()    { PINA |= (1<<2); }
+    static void toggle() { PINA |= (1 << 2); }
 
     /// Configures PinA2  as an output pin.
-    static void setOutput() { DDRA |= (1<<2); }
+    static void setOutput() { DDRA |= (1 << 2); }
 
     /// Configures PinA2  as an input pin.
-    static void setInput()  { DDRA &= ~(1<<2); }
+    static void setInput() { DDRA &= ~(1 << 2); }
 
     /// Pulses PinA2 with high state first.
-    static void pulseHigh() { PORTA |= (1<<2); PORTA &= ~(1<<2); }
+    static void pulseHigh() {
+        PORTA |= (1 << 2);
+        PORTA &= ~(1 << 2);
+    }
 
     /// Pulses PinA2 with low state first.
-    static void pulseLow()  { PORTA &= ~(1<<2); PORTA |= (1<<2); }
+    static void pulseLow() {
+        PORTA &= ~(1 << 2);
+        PORTA |= (1 << 2);
+    }
 
     /// Reads PinA2  value.
     /// @return Port pin value.
-    static bool test()      { return PINA & (1<<2); }
+    static bool test() { return PINA & (1 << 2); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<2)
-    static constexpr uint8_t bitmask()               { return (1<<2); }
+    static constexpr uint8_t bitmask() { return (1 << 2); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 2
-    static constexpr uint8_t bit()                   { return 2; }
+    static constexpr uint8_t bit() { return 2; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortA;
@@ -345,39 +389,45 @@ struct PinA2 {
 
 struct PinA1 {
     /// Sets PinA1 to HIGH.
-    static void set()       { PORTA |= (1<<1); }
+    static void set() { PORTA |= (1 << 1); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinA1 to LOW.
-    static void clear()     { PORTA &= ~(1<<1); }
+    static void clear() { PORTA &= ~(1 << 1); }
 
     /// Toggles PinA1 value.
-    static void toggle()    { PINA |= (1<<1); }
+    static void toggle() { PINA |= (1 << 1); }
 
     /// Configures PinA1  as an output pin.
-    static void setOutput() { DDRA |= (1<<1); }
+    static void setOutput() { DDRA |= (1 << 1); }
 
     /// Configures PinA1  as an input pin.
-    static void setInput()  { DDRA &= ~(1<<1); }
+    static void setInput() { DDRA &= ~(1 << 1); }
 
     /// Pulses PinA1 with high state first.
-    static void pulseHigh() { PORTA |= (1<<1); PORTA &= ~(1<<1); }
+    static void pulseHigh() {
+        PORTA |= (1 << 1);
+        PORTA &= ~(1 << 1);
+    }
 
     /// Pulses PinA1 with low state first.
-    static void pulseLow()  { PORTA &= ~(1<<1); PORTA |= (1<<1); }
+    static void pulseLow() {
+        PORTA &= ~(1 << 1);
+        PORTA |= (1 << 1);
+    }
 
     /// Reads PinA1  value.
     /// @return Port pin value.
-    static bool test()      { return PINA & (1<<1); }
+    static bool test() { return PINA & (1 << 1); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<1)
-    static constexpr uint8_t bitmask()               { return (1<<1); }
+    static constexpr uint8_t bitmask() { return (1 << 1); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 1
-    static constexpr uint8_t bit()                   { return 1; }
+    static constexpr uint8_t bit() { return 1; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortA;
@@ -385,134 +435,153 @@ struct PinA1 {
 
 struct PinA0 {
     /// Sets PinA0 to HIGH.
-    static void set()       { PORTA |= (1<<0); }
+    static void set() { PORTA |= (1 << 0); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinA0 to LOW.
-    static void clear()     { PORTA &= ~(1<<0); }
+    static void clear() { PORTA &= ~(1 << 0); }
 
     /// Toggles PinA0 value.
-    static void toggle()    { PINA |= (1<<0); }
+    static void toggle() { PINA |= (1 << 0); }
 
     /// Configures PinA0  as an output pin.
-    static void setOutput() { DDRA |= (1<<0); }
+    static void setOutput() { DDRA |= (1 << 0); }
 
     /// Configures PinA0  as an input pin.
-    static void setInput()  { DDRA &= ~(1<<0); }
+    static void setInput() { DDRA &= ~(1 << 0); }
 
     /// Pulses PinA0 with high state first.
-    static void pulseHigh() { PORTA |= (1<<0); PORTA &= ~(1<<0); }
+    static void pulseHigh() {
+        PORTA |= (1 << 0);
+        PORTA &= ~(1 << 0);
+    }
 
     /// Pulses PinA0 with low state first.
-    static void pulseLow()  { PORTA &= ~(1<<0); PORTA |= (1<<0); }
+    static void pulseLow() {
+        PORTA &= ~(1 << 0);
+        PORTA |= (1 << 0);
+    }
 
     /// Reads PinA0  value.
     /// @return Port pin value.
-    static bool test()      { return PINA & (1<<0); }
+    static bool test() { return PINA & (1 << 0); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<0)
-    static constexpr uint8_t bitmask()               { return (1<<0); }
+    static constexpr uint8_t bitmask() { return (1 << 0); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 0
-    static constexpr uint8_t bit()                   { return 0; }
+    static constexpr uint8_t bit() { return 0; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortA;
 };
 
-
 struct PortB {
 
     /// Assigns a value to PORTB
     /// @param[in] value value affected to PORTB
-    static void assign(uint8_t value)   { PORTB = value; }
+    static void assign(uint8_t value) { PORTB = value; }
 
     /// Sets masked bits in PORTB
     /// @param[in] mask bits to set
-    static void setBits(uint8_t mask)   { PORTB |= mask;}
+    static void setBits(uint8_t mask) { PORTB |= mask; }
 
     /// Clears masked bits in PORTB
     /// @param[in] mask bits to clear
-    static void clearBits(uint8_t mask) { PORTB &= ~mask;} 
+    static void clearBits(uint8_t mask) { PORTB &= ~mask; }
 
     /// Changes values of masked bits in PORTB
     /// @param[in] mask bits to change
     /// @param[in] value new bits values
-    static void changeBits(uint8_t mask, uint8_t value) { uint8_t tmp = PORTB & ~mask; PORTB = tmp | value; } 
+    static void changeBits(uint8_t mask, uint8_t value) {
+        uint8_t tmp = PORTB & ~mask;
+        PORTB = tmp | value;
+    }
 
     /// Toggles masked bits in PORTB
     /// @param[in] mask bits to toggle
-    static void toggleBits(uint8_t mask) { PORTB ^= mask;} 
+    static void toggleBits(uint8_t mask) { PORTB ^= mask; }
 
     /// Pulses masked bits in PORTB with high state first.
     /// @param[in] mask bits to pulse
-    static void pulseHigh(uint8_t mask) { PORTB |= mask; PORTB &= ~mask; }
+    static void pulseHigh(uint8_t mask) {
+        PORTB |= mask;
+        PORTB &= ~mask;
+    }
 
     /// Pulses masked bits in PORTB with low state first.
     /// @param[in] mask bits to pulse
-    static void pulseLow(uint8_t mask)  { PORTB &= ~mask; PORTB |= mask; }
+    static void pulseLow(uint8_t mask) {
+        PORTB &= ~mask;
+        PORTB |= mask;
+    }
 
     /// Set corresponding masked bits of PORTB to output direction.
     /// @param[in] mask bits
-    static void setOutput(uint8_t mask)    { DDRB |= mask; }
+    static void setOutput(uint8_t mask) { DDRB |= mask; }
 
     /// Set corresponding masked bits of PORTB to input direction.
     /// @param[in] mask bits
-    static void setInput(uint8_t mask)  { DDRB &= ~mask; }
+    static void setInput(uint8_t mask) { DDRB &= ~mask; }
 
     /// Returns PINB register.
-    static uint8_t getPIN()             { return PINB; }
+    static uint8_t getPIN() { return PINB; }
 
     /// Tests masked bits of PORTB
     /// @param[in] mask bits
     /// @param[in] true if the corresponding bits are all set, false otherwise.
-    static bool testBits(uint8_t mask)  { return (PINB & mask) == mask; }
+    static bool testBits(uint8_t mask) { return (PINB & mask) == mask; }
 
     /// Returns the value of the bit at the position pos.
     /// @param[in] position of the bit to return
     /// @return true if the requested bit is set, false otherwise.
-    static bool test(uint8_t pos) { return PINB & (1<<pos); }
-
+    static bool test(uint8_t pos) { return PINB & (1 << pos); }
 };
 
 struct PinB3 {
     /// Sets PinB3 to HIGH.
-    static void set()       { PORTB |= (1<<3); }
+    static void set() { PORTB |= (1 << 3); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinB3 to LOW.
-    static void clear()     { PORTB &= ~(1<<3); }
+    static void clear() { PORTB &= ~(1 << 3); }
 
     /// Toggles PinB3 value.
-    static void toggle()    { PINB |= (1<<3); }
+    static void toggle() { PINB |= (1 << 3); }
 
     /// Configures PinB3  as an output pin.
-    static void setOutput() { DDRB |= (1<<3); }
+    static void setOutput() { DDRB |= (1 << 3); }
 
     /// Configures PinB3  as an input pin.
-    static void setInput()  { DDRB &= ~(1<<3); }
+    static void setInput() { DDRB &= ~(1 << 3); }
 
     /// Pulses PinB3 with high state first.
-    static void pulseHigh() { PORTB |= (1<<3); PORTB &= ~(1<<3); }
+    static void pulseHigh() {
+        PORTB |= (1 << 3);
+        PORTB &= ~(1 << 3);
+    }
 
     /// Pulses PinB3 with low state first.
-    static void pulseLow()  { PORTB &= ~(1<<3); PORTB |= (1<<3); }
+    static void pulseLow() {
+        PORTB &= ~(1 << 3);
+        PORTB |= (1 << 3);
+    }
 
     /// Reads PinB3  value.
     /// @return Port pin value.
-    static bool test()      { return PINB & (1<<3); }
+    static bool test() { return PINB & (1 << 3); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<3)
-    static constexpr uint8_t bitmask()               { return (1<<3); }
+    static constexpr uint8_t bitmask() { return (1 << 3); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 3
-    static constexpr uint8_t bit()                   { return 3; }
+    static constexpr uint8_t bit() { return 3; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortB;
@@ -520,39 +589,45 @@ struct PinB3 {
 
 struct PinB2 {
     /// Sets PinB2 to HIGH.
-    static void set()       { PORTB |= (1<<2); }
+    static void set() { PORTB |= (1 << 2); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinB2 to LOW.
-    static void clear()     { PORTB &= ~(1<<2); }
+    static void clear() { PORTB &= ~(1 << 2); }
 
     /// Toggles PinB2 value.
-    static void toggle()    { PINB |= (1<<2); }
+    static void toggle() { PINB |= (1 << 2); }
 
     /// Configures PinB2  as an output pin.
-    static void setOutput() { DDRB |= (1<<2); }
+    static void setOutput() { DDRB |= (1 << 2); }
 
     /// Configures PinB2  as an input pin.
-    static void setInput()  { DDRB &= ~(1<<2); }
+    static void setInput() { DDRB &= ~(1 << 2); }
 
     /// Pulses PinB2 with high state first.
-    static void pulseHigh() { PORTB |= (1<<2); PORTB &= ~(1<<2); }
+    static void pulseHigh() {
+        PORTB |= (1 << 2);
+        PORTB &= ~(1 << 2);
+    }
 
     /// Pulses PinB2 with low state first.
-    static void pulseLow()  { PORTB &= ~(1<<2); PORTB |= (1<<2); }
+    static void pulseLow() {
+        PORTB &= ~(1 << 2);
+        PORTB |= (1 << 2);
+    }
 
     /// Reads PinB2  value.
     /// @return Port pin value.
-    static bool test()      { return PINB & (1<<2); }
+    static bool test() { return PINB & (1 << 2); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<2)
-    static constexpr uint8_t bitmask()               { return (1<<2); }
+    static constexpr uint8_t bitmask() { return (1 << 2); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 2
-    static constexpr uint8_t bit()                   { return 2; }
+    static constexpr uint8_t bit() { return 2; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortB;
@@ -560,39 +635,45 @@ struct PinB2 {
 
 struct PinB1 {
     /// Sets PinB1 to HIGH.
-    static void set()       { PORTB |= (1<<1); }
+    static void set() { PORTB |= (1 << 1); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinB1 to LOW.
-    static void clear()     { PORTB &= ~(1<<1); }
+    static void clear() { PORTB &= ~(1 << 1); }
 
     /// Toggles PinB1 value.
-    static void toggle()    { PINB |= (1<<1); }
+    static void toggle() { PINB |= (1 << 1); }
 
     /// Configures PinB1  as an output pin.
-    static void setOutput() { DDRB |= (1<<1); }
+    static void setOutput() { DDRB |= (1 << 1); }
 
     /// Configures PinB1  as an input pin.
-    static void setInput()  { DDRB &= ~(1<<1); }
+    static void setInput() { DDRB &= ~(1 << 1); }
 
     /// Pulses PinB1 with high state first.
-    static void pulseHigh() { PORTB |= (1<<1); PORTB &= ~(1<<1); }
+    static void pulseHigh() {
+        PORTB |= (1 << 1);
+        PORTB &= ~(1 << 1);
+    }
 
     /// Pulses PinB1 with low state first.
-    static void pulseLow()  { PORTB &= ~(1<<1); PORTB |= (1<<1); }
+    static void pulseLow() {
+        PORTB &= ~(1 << 1);
+        PORTB |= (1 << 1);
+    }
 
     /// Reads PinB1  value.
     /// @return Port pin value.
-    static bool test()      { return PINB & (1<<1); }
+    static bool test() { return PINB & (1 << 1); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<1)
-    static constexpr uint8_t bitmask()               { return (1<<1); }
+    static constexpr uint8_t bitmask() { return (1 << 1); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 1
-    static constexpr uint8_t bit()                   { return 1; }
+    static constexpr uint8_t bit() { return 1; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortB;
@@ -600,157 +681,205 @@ struct PinB1 {
 
 struct PinB0 {
     /// Sets PinB0 to HIGH.
-    static void set()       { PORTB |= (1<<0); }
+    static void set() { PORTB |= (1 << 0); }
 
     static void set(bool v) { v ? set() : clear(); }
 
     /// Sets PinB0 to LOW.
-    static void clear()     { PORTB &= ~(1<<0); }
+    static void clear() { PORTB &= ~(1 << 0); }
 
     /// Toggles PinB0 value.
-    static void toggle()    { PINB |= (1<<0); }
+    static void toggle() { PINB |= (1 << 0); }
 
     /// Configures PinB0  as an output pin.
-    static void setOutput() { DDRB |= (1<<0); }
+    static void setOutput() { DDRB |= (1 << 0); }
 
     /// Configures PinB0  as an input pin.
-    static void setInput()  { DDRB &= ~(1<<0); }
+    static void setInput() { DDRB &= ~(1 << 0); }
 
     /// Pulses PinB0 with high state first.
-    static void pulseHigh() { PORTB |= (1<<0); PORTB &= ~(1<<0); }
+    static void pulseHigh() {
+        PORTB |= (1 << 0);
+        PORTB &= ~(1 << 0);
+    }
 
     /// Pulses PinB0 with low state first.
-    static void pulseLow()  { PORTB &= ~(1<<0); PORTB |= (1<<0); }
+    static void pulseLow() {
+        PORTB &= ~(1 << 0);
+        PORTB |= (1 << 0);
+    }
 
     /// Reads PinB0  value.
     /// @return Port pin value.
-    static bool test()      { return PINB & (1<<0); }
+    static bool test() { return PINB & (1 << 0); }
 
     /// Returns the bitmask corresponding to this pin.
     /// @return (1<<0)
-    static constexpr uint8_t bitmask()               { return (1<<0); }
+    static constexpr uint8_t bitmask() { return (1 << 0); }
 
     /// Returns the bit corresponding to this pin.
     /// @return 0
-    static constexpr uint8_t bit()                   { return 0; }
+    static constexpr uint8_t bit() { return 0; }
 
     /// Port is defined as the Port object to which this pin belongs.
     using Port = PortB;
 };
 
-
 struct Timer0 {
-  using value_type = uint8_t;
-  static const uint8_t timer_width = 8;
+    using value_type = uint8_t;
+    static const uint8_t timer_width = 8;
 
-  enum Prescaler : uint8_t {
-    STOP_TIMER = 0, NO_PRESCALER = (1<<CS00), CLK_DIV_8 = (1<<CS01),
-    CLK_DIV_32 = (1<<CS01)|(1<<CS00), CLK_DIV_64 = (1<<CS02),
-    CLK_DIV_128 = (1<<CS02)|(1<<CS00), CLK_DIV_256 = (1<<CS02)|(1<<CS01),
-    CLK_DIV_1024 = (1<<CS02)|(1<<CS01)|(1<<CS00), BITS = (1<<CS02)|(1<<CS01)|(1<<CS00) };
+    enum Prescaler : uint8_t {
+        STOP_TIMER = 0,
+        NO_PRESCALER = (1 << CS00),
+        CLK_DIV_8 = (1 << CS01),
+        CLK_DIV_32 = (1 << CS01) | (1 << CS00),
+        CLK_DIV_64 = (1 << CS02),
+        CLK_DIV_128 = (1 << CS02) | (1 << CS00),
+        CLK_DIV_256 = (1 << CS02) | (1 << CS01),
+        CLK_DIV_1024 = (1 << CS02) | (1 << CS01) | (1 << CS00),
+        BITS = (1 << CS02) | (1 << CS01) | (1 << CS00)
+    };
 
-  enum Interrupt : uint8_t { 
-    OVERFLOW = (1<<TOIE0), COMPARE_MATCH_A = (1<<OCIE0A), COMPARE_MATCH_B = (1<<OCIE0B)};
-  enum Constants : uint8_t { ALL_BITS = 0xFF };
-  static value_type getValue()                 { return TCNT0; }
-  static void setValue(value_type value)       { TCNT0 = value; }
-  static void addValue(value_type value)       { TCNT0 += value; }
-  static void subValue(value_type value)       { TCNT0 -= value; }
-  static void setCtrlRegA(uint8_t mask)        { TCCR0A |= mask; }
-  static void clearCtrlRegA(uint8_t mask)      { TCCR0A &= ~mask; }
-  static void setCtrlRegB(uint8_t mask)        { TCCR0B |= mask; }
-  static void clearCtrlRegB(uint8_t mask)      { TCCR0B &= ~mask; }
-  static void setInterruptMask(uint8_t mask)   { TIMSK0 |= mask; }
-  static void clearInterruptMask(uint8_t mask) { TIMSK0 &= ~mask; }
-  static void setPrescaler(Prescaler val)      { TCCR0B &= ~Prescaler::BITS; TCCR0B |= val; }
-  static void setOutputCompareValueA(value_type value) { OCR0A = value; }
-  static value_type getOutputCompareValueA()           { return OCR0A; }
-  static void setOutputCompareValueB(value_type value) { OCR0B = value; }
-  static value_type getOutputCompareValueB()           { return OCR0B; }
+    enum Interrupt : uint8_t { OVERFLOW = (1 << TOIE0), COMPARE_MATCH_A = (1 << OCIE0A), COMPARE_MATCH_B = (1 << OCIE0B) };
+    enum Constants : uint8_t { ALL_BITS = 0xFF };
+    static value_type getValue() { return TCNT0; }
+    static void setValue(value_type value) { TCNT0 = value; }
+    static void addValue(value_type value) { TCNT0 += value; }
+    static void subValue(value_type value) { TCNT0 -= value; }
+    static void setCtrlRegA(uint8_t mask) { TCCR0A |= mask; }
+    static void clearCtrlRegA(uint8_t mask) { TCCR0A &= ~mask; }
+    static void setCtrlRegB(uint8_t mask) { TCCR0B |= mask; }
+    static void clearCtrlRegB(uint8_t mask) { TCCR0B &= ~mask; }
+    static void setInterruptMask(uint8_t mask) { TIMSK0 |= mask; }
+    static void clearInterruptMask(uint8_t mask) { TIMSK0 &= ~mask; }
+    static void setPrescaler(Prescaler val) {
+        TCCR0B &= ~Prescaler::BITS;
+        TCCR0B |= val;
+    }
+    static void setOutputCompareValueA(value_type value) { OCR0A = value; }
+    static value_type getOutputCompareValueA() { return OCR0A; }
+    static void setOutputCompareValueB(value_type value) { OCR0B = value; }
+    static value_type getOutputCompareValueB() { return OCR0B; }
 
-  struct Isr {
-    static void Overflow() IOPORTS_IRQ_HANDLER(TIMER0_OVF_vect, signal);
-    static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER0_COMPA_vect, signal);
-    static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER0_COMPB_vect, signal);
-  };
+    struct Isr {
+        static void Overflow() IOPORTS_IRQ_HANDLER(TIMER0_OVF_vect, signal);
+        static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER0_COMPA_vect, signal);
+        static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER0_COMPB_vect, signal);
+    };
 
-  struct IsrNoBlock {
-    static void Overflow() IOPORTS_IRQ_HANDLER(TIMER0_OVF_vect, interrupt);
-    static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER0_COMPA_vect, interrupt);
-    static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER0_COMPB_vect, interrupt);
-  };
+    struct IsrNoBlock {
+        static void Overflow() IOPORTS_IRQ_HANDLER(TIMER0_OVF_vect, interrupt);
+        static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER0_COMPA_vect, interrupt);
+        static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER0_COMPB_vect, interrupt);
+    };
 
-  struct IsrNaked {
-    static void Overflow() IOPORTS_IRQ_HANDLER(TIMER0_OVF_vect, naked);
-    static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER0_COMPA_vect, naked);
-    static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER0_COMPB_vect, naked);
-  };
-};  
+    struct IsrNaked {
+        static void Overflow() IOPORTS_IRQ_HANDLER(TIMER0_OVF_vect, naked);
+        static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER0_COMPA_vect, naked);
+        static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER0_COMPB_vect, naked);
+    };
+};
 
 struct Timer1 {
-  using value_type = uint16_t;
-  static const uint8_t timer_width = 16;
+    using value_type = uint16_t;
+    static const uint8_t timer_width = 16;
 
-  enum Prescaler : uint8_t {
-    STOP_TIMER = 0, NO_PRESCALER = (1<<CS10), CLK_DIV_8 = (1<<CS11),
-    CLK_DIV_32 = (1<<CS11)|(1<<CS10), CLK_DIV_64 = (1<<CS12),
-    CLK_DIV_128 = (1<<CS12)|(1<<CS10), CLK_DIV_256 = (1<<CS12)|(1<<CS11),
-    CLK_DIV_1024 = (1<<CS12)|(1<<CS11)|(1<<CS10), BITS = (1<<CS12)|(1<<CS11)|(1<<CS10) };
+    enum Prescaler : uint8_t {
+        STOP_TIMER = 0,
+        NO_PRESCALER = (1 << CS10),
+        CLK_DIV_8 = (1 << CS11),
+        CLK_DIV_32 = (1 << CS11) | (1 << CS10),
+        CLK_DIV_64 = (1 << CS12),
+        CLK_DIV_128 = (1 << CS12) | (1 << CS10),
+        CLK_DIV_256 = (1 << CS12) | (1 << CS11),
+        CLK_DIV_1024 = (1 << CS12) | (1 << CS11) | (1 << CS10),
+        BITS = (1 << CS12) | (1 << CS11) | (1 << CS10)
+    };
 
-  enum Interrupt : uint8_t { 
-    OVERFLOW = (1<<TOIE1), CAPTURE = (1<<ICIE1), COMPARE_MATCH_A = (1<<OCIE1A), COMPARE_MATCH_B = (1<<OCIE1B)};
-  enum Constants : uint8_t { ALL_BITS = 0xFF };
-  static value_type getValue()                 { return TCNT1; }
-  static void setValue(value_type value)       { TCNT1 = value; }
-  static void addValue(value_type value)       { TCNT1 += value; }
-  static void subValue(value_type value)       { TCNT1 -= value; }
-  static void setCtrlRegA(uint8_t mask)        { TCCR1A |= mask; }
-  static void clearCtrlRegA(uint8_t mask)      { TCCR1A &= ~mask; }
-  static void setCtrlRegB(uint8_t mask)        { TCCR1B |= mask; }
-  static void clearCtrlRegB(uint8_t mask)      { TCCR1B &= ~mask; }
-  static void setInterruptMask(uint8_t mask)   { TIMSK1 |= mask; }
-  static void clearInterruptMask(uint8_t mask) { TIMSK1 &= ~mask; }
-  static void setPrescaler(Prescaler val)      { TCCR1B &= ~Prescaler::BITS; TCCR1B |= val; }
-  static void setOutputCompareValueA(value_type value) { OCR1A = value; }
-  static value_type getOutputCompareValueA()           { return OCR1A; }
-  static void setOutputCompareValueB(value_type value) { OCR1B = value; }
-  static value_type getOutputCompareValueB()           { return OCR1B; }
+    enum Interrupt : uint8_t {
+        OVERFLOW = (1 << TOIE1),
+        CAPTURE = (1 << ICIE1),
+        COMPARE_MATCH_A = (1 << OCIE1A),
+        COMPARE_MATCH_B = (1 << OCIE1B)
+    };
+    enum Constants : uint8_t { ALL_BITS = 0xFF };
+    static value_type getValue() { return TCNT1; }
+    static void setValue(value_type value) { TCNT1 = value; }
+    static void addValue(value_type value) { TCNT1 += value; }
+    static void subValue(value_type value) { TCNT1 -= value; }
+    static void setCtrlRegA(uint8_t mask) { TCCR1A |= mask; }
+    static void clearCtrlRegA(uint8_t mask) { TCCR1A &= ~mask; }
+    static void setCtrlRegB(uint8_t mask) { TCCR1B |= mask; }
+    static void clearCtrlRegB(uint8_t mask) { TCCR1B &= ~mask; }
+    static void setInterruptMask(uint8_t mask) { TIMSK1 |= mask; }
+    static void clearInterruptMask(uint8_t mask) { TIMSK1 &= ~mask; }
+    static void setPrescaler(Prescaler val) {
+        TCCR1B &= ~Prescaler::BITS;
+        TCCR1B |= val;
+    }
+    static void setOutputCompareValueA(value_type value) { OCR1A = value; }
+    static value_type getOutputCompareValueA() { return OCR1A; }
+    static void setOutputCompareValueB(value_type value) { OCR1B = value; }
+    static value_type getOutputCompareValueB() { return OCR1B; }
 
-  struct Isr {
-    static void Overflow() IOPORTS_IRQ_HANDLER(TIMER1_OVF_vect, signal);
-    static void Capture() IOPORTS_IRQ_HANDLER(TIMER1_CAPT_vect, signal);
-    static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER1_COMPA_vect, signal);
-    static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER1_COMPB_vect, signal);
-  };
+    struct Isr {
+        static void Overflow() IOPORTS_IRQ_HANDLER(TIMER1_OVF_vect, signal);
+        static void Capture() IOPORTS_IRQ_HANDLER(TIMER1_CAPT_vect, signal);
+        static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER1_COMPA_vect, signal);
+        static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER1_COMPB_vect, signal);
+    };
 
-  struct IsrNoBlock {
-    static void Overflow() IOPORTS_IRQ_HANDLER(TIMER1_OVF_vect, interrupt);
-    static void Capture() IOPORTS_IRQ_HANDLER(TIMER1_CAPT_vect, interrupt);
-    static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER1_COMPA_vect, interrupt);
-    static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER1_COMPB_vect, interrupt);
-  };
+    struct IsrNoBlock {
+        static void Overflow() IOPORTS_IRQ_HANDLER(TIMER1_OVF_vect, interrupt);
+        static void Capture() IOPORTS_IRQ_HANDLER(TIMER1_CAPT_vect, interrupt);
+        static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER1_COMPA_vect, interrupt);
+        static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER1_COMPB_vect, interrupt);
+    };
 
-  struct IsrNaked {
-    static void Overflow() IOPORTS_IRQ_HANDLER(TIMER1_OVF_vect, naked);
-    static void Capture() IOPORTS_IRQ_HANDLER(TIMER1_CAPT_vect, naked);
-    static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER1_COMPA_vect, naked);
-    static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER1_COMPB_vect, naked);
-  };
-};  
+    struct IsrNaked {
+        static void Overflow() IOPORTS_IRQ_HANDLER(TIMER1_OVF_vect, naked);
+        static void Capture() IOPORTS_IRQ_HANDLER(TIMER1_CAPT_vect, naked);
+        static void CompareMatchA() IOPORTS_IRQ_HANDLER(TIMER1_COMPA_vect, naked);
+        static void CompareMatchB() IOPORTS_IRQ_HANDLER(TIMER1_COMPB_vect, naked);
+    };
+};
 
-template<typename> struct is_uart_txd_capable : std::false_type {};
-template<typename> struct is_uart_rxd_capable : std::false_type {};
+template <typename> struct is_uart_txd_capable : ETLSTD::false_type {};
+template <typename> struct is_uart_rxd_capable : ETLSTD::false_type {};
 enum FrameFormat {
-    _5N1 = 0b00000, _5N2 = 0b000001, _5E1 = 0b00010, _5E2 = 0b00011, _5O1 = 0b00100, _5O2 = 0b00101,       // Encoding 5-N-1 : nbBits - no, even or odd parity - 1 or 2 stop bits : 0b00 - 00 - 0
-    _6N1 = 0b01000, _6N2 = 0b010001, _6E1 = 0b01010, _6E2 = 0b01011, _6O1 = 0b01100, _6O2 = 0b01101,
-    _7N1 = 0b10000, _7N2 = 0b100001, _7E1 = 0b10010, _7E2 = 0b10011, _7O1 = 0b10100, _7O2 = 0b10101,
-    _8N1 = 0b11000, _8N2 = 0b110001, _8E1 = 0b11010, _8E2 = 0b11011, _8O1 = 0b11100, _8O2 = 0b11101,
-    NbBitsMask = 0b11000, ParityMask = 0b00110, StopBitMask = 0b00001
+    _5N1 = 0b00000,
+    _5N2 = 0b000001,
+    _5E1 = 0b00010,
+    _5E2 = 0b00011,
+    _5O1 = 0b00100,
+    _5O2 = 0b00101, // Encoding 5-N-1 : nbBits - no, even or odd parity - 1 or 2 stop bits : 0b00 - 00 - 0
+    _6N1 = 0b01000,
+    _6N2 = 0b010001,
+    _6E1 = 0b01010,
+    _6E2 = 0b01011,
+    _6O1 = 0b01100,
+    _6O2 = 0b01101,
+    _7N1 = 0b10000,
+    _7N2 = 0b100001,
+    _7E1 = 0b10010,
+    _7E2 = 0b10011,
+    _7O1 = 0b10100,
+    _7O2 = 0b10101,
+    _8N1 = 0b11000,
+    _8N2 = 0b110001,
+    _8E1 = 0b11010,
+    _8E2 = 0b11011,
+    _8O1 = 0b11100,
+    _8O2 = 0b11101,
+    NbBitsMask = 0b11000,
+    ParityMask = 0b00110,
+    StopBitMask = 0b00001
 };
 #ifdef PCICR
 struct PinChangeControlRegister {
-  static void setBits(uint8_t mask)   { PCICR |= mask; }
-  static void clearBits(uint8_t mask) { PCICR &= ~mask; }
+    static void setBits(uint8_t mask) { PCICR |= mask; }
+    static void clearBits(uint8_t mask) { PCICR &= ~mask; }
 };
 #endif // PCICR
 

--- a/libstd/include/array
+++ b/libstd/include/array
@@ -99,7 +99,7 @@ template <typename T, size_t N> struct array {
     void fill(const T &value) { fill_n(begin(), size(), value); }
     void swap(array &other) noexcept { swap_ranges(begin(), end(), other.begin()); }
 
-private:
+public:
     T elems[N];
 
 private:

--- a/libstd/include/array
+++ b/libstd/include/array
@@ -32,174 +32,188 @@
 //  POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
-#include <libstd/include/iterator>
 #include <libstd/include/algorithm>
+#include <libstd/include/iterator>
 #include <libstd/include/stdexcept>
 
 namespace ETLSTD {
 
-template<typename T, size_t N>
-struct array {
-    using value_type        = T;
-    using pointer           = T*;
-    using const_pointer     = const T;
-    using reference         = T&;
-    using const_reference   = const T&;
-    using iterator          = T*;
-    using const_iterator    = const T*;
-    using size_type         = size_t;
-    using difference_type   = ptrdiff_t;
-    using reverse_iterator  = ETLSTD::reverse_iterator<iterator>;
-    using const_reverse_iterator  = ETLSTD::reverse_iterator<const_iterator>;
-  
+template <typename T, size_t N> struct array {
+    using value_type = T;
+    using pointer = T *;
+    using const_pointer = const T;
+    using reference = T &;
+    using const_reference = const T &;
+    using iterator = T *;
+    using const_iterator = const T *;
+    using size_type = size_t;
+    using difference_type = ptrdiff_t;
+    using reverse_iterator = ETLSTD::reverse_iterator<iterator>;
+    using const_reverse_iterator = ETLSTD::reverse_iterator<const_iterator>;
+
     // Access
-    reference operator[](size_type i) noexcept              { return elems[i]; }
-    constexpr const_reference operator[](size_type i) const  { return elems[i]; }
-    
-    reference at(size_type i)       { CheckRange(i); return elems[i]; }
-    constexpr const_reference at(size_type i) const { CheckRange(i); return elems[i]; }
-   
-    reference front() noexcept                        { return elems[0]; }
-    constexpr const_reference front() const noexcept  { return elems[0]; }
-    reference back() noexcept                         { return elems[N - 1]; }
-    constexpr const_reference back() const noexcept   { return elems[N - 1]; }
-    pointer data() noexcept                           { return elems; }
-    constexpr const_pointer data() const noexcept     { return elems; }
-    
+    reference operator[](size_type i) noexcept { return elems[i]; }
+    constexpr const_reference operator[](size_type i) const { return elems[i]; }
+
+    reference at(size_type i) {
+        CheckRange(i);
+        return elems[i];
+    }
+    constexpr const_reference at(size_type i) const {
+        CheckRange(i);
+        return elems[i];
+    }
+
+    reference front() noexcept { return elems[0]; }
+    constexpr const_reference front() const noexcept { return elems[0]; }
+    reference back() noexcept { return elems[N - 1]; }
+    constexpr const_reference back() const noexcept { return elems[N - 1]; }
+    pointer data() noexcept { return elems; }
+    constexpr const_pointer data() const noexcept { return elems; }
+
     // Size
     constexpr size_type size() const noexcept { return N; }
     constexpr size_type max_size() const noexcept { return N; }
     constexpr bool empty() const noexcept { return size() == 0; }
-    
+
     // Iterators
     iterator begin() noexcept { return elems; }
-    iterator end() noexcept   { return elems + N; }
-    
+    iterator end() noexcept { return elems + N; }
+
     const_iterator begin() const noexcept { return elems; }
-    const_iterator end() const noexcept   { return elems + N; }
-  
+    const_iterator end() const noexcept { return elems + N; }
+
     reverse_iterator rbegin() noexcept { return reverse_iterator(end()); }
-    reverse_iterator rend() noexcept   { return reverse_iterator(begin()); }
-    
+    reverse_iterator rend() noexcept { return reverse_iterator(begin()); }
+
     const_reverse_iterator rbegin() const noexcept { return const_reverse_iterator(end()); }
-    const_reverse_iterator rend() const noexcept   { return const_reverse_iterator(begin()); }
-   
+    const_reverse_iterator rend() const noexcept { return const_reverse_iterator(begin()); }
+
     const_iterator cbegin() const noexcept { return elems; }
-    const_iterator cend() const noexcept   { return elems + N; }
-  
+    const_iterator cend() const noexcept { return elems + N; }
+
     const_reverse_iterator crbegin() const noexcept { return const_reverse_iterator(end()); }
     const_reverse_iterator crend() const noexcept { return const_reverse_iterator(begin()); }
-    
+
     // Operations
-    void fill(const T& value) { fill_n(begin(), size(), value); }    
-    void swap(array& other) noexcept { swap_ranges(begin(), end(), other.begin()); }
-    
+    void fill(const T &value) { fill_n(begin(), size(), value); }
+    void swap(array &other) noexcept { swap_ranges(begin(), end(), other.begin()); }
+
 private:
     T elems[N];
-  
+
 private:
     void CheckRange(size_type i) {
         if (i >= size()) {
             out_of_range exception("");
             throw(exception);
-       }      
-    }    
+        }
+    }
 };
 
 // Zero-sized array specialization
-template<typename T>
-struct array<T, 0> {
-    using value_type        = T;
-    using pointer           = T*;
-    using const_pointer     = const T;
-    using reference         = T&;
-    using const_reference   = const T&;
-    using iterator          = T*;
-    using const_iterator    = const T*;
-    using size_type         = size_t;
-    using difference_type   = ptrdiff_t;
-    using reverse_iterator  = ETLSTD::reverse_iterator<iterator>;
-    using const_reverse_iterator  = ETLSTD::reverse_iterator<const_iterator>;
-  
+template <typename T> struct array<T, 0> {
+    using value_type = T;
+    using pointer = T *;
+    using const_pointer = const T;
+    using reference = T &;
+    using const_reference = const T &;
+    using iterator = T *;
+    using const_iterator = const T *;
+    using size_type = size_t;
+    using difference_type = ptrdiff_t;
+    using reverse_iterator = ETLSTD::reverse_iterator<iterator>;
+    using const_reverse_iterator = ETLSTD::reverse_iterator<const_iterator>;
+
     // Access
-    reference operator[](size_type)                       { RangeError(); return elems; }
-    constexpr const_reference operator[](size_type) const { RangeError(); return elems; }   
-    reference at(size_type)                               { RangeError(); return elems; }
-    constexpr const_reference at(size_type) const         { RangeError(); return elems; }
-    reference front()                                     { RangeError(); return elems; }
-    constexpr const_reference front() const               { RangeError(); return elems; }
-    reference back()                                      { RangeError(); return elems; }
-    constexpr const_reference back() const                { RangeError(); return elems; }
-    pointer data() noexcept                               { return nullptr; }
-    constexpr const_pointer data() const noexcept         { return nullptr; }
-    
+    reference operator[](size_type) {
+        RangeError();
+        return elems;
+    }
+    constexpr const_reference operator[](size_type) const {
+        RangeError();
+        return elems;
+    }
+    reference at(size_type) {
+        RangeError();
+        return elems;
+    }
+    constexpr const_reference at(size_type) const {
+        RangeError();
+        return elems;
+    }
+    reference front() {
+        RangeError();
+        return elems;
+    }
+    constexpr const_reference front() const {
+        RangeError();
+        return elems;
+    }
+    reference back() {
+        RangeError();
+        return elems;
+    }
+    constexpr const_reference back() const {
+        RangeError();
+        return elems;
+    }
+    pointer data() noexcept { return nullptr; }
+    constexpr const_pointer data() const noexcept { return nullptr; }
+
     // Size
     constexpr size_type size() const noexcept { return 0; }
     constexpr size_type max_size() const noexcept { return 0; }
     constexpr bool empty() const noexcept { return true; }
-    
+
     // Iterators
-    iterator begin() noexcept { return iterator(reinterpret_cast<T*>(this)); }
-    iterator end() noexcept   { return begin(); }
-    
-    const_iterator begin() const noexcept { return const_iterator(reinterpret_cast<const T*>(this)); }
-    const_iterator end() const noexcept   { return begin(); }
-  
+    iterator begin() noexcept { return iterator(reinterpret_cast<T *>(this)); }
+    iterator end() noexcept { return begin(); }
+
+    const_iterator begin() const noexcept { return const_iterator(reinterpret_cast<const T *>(this)); }
+    const_iterator end() const noexcept { return begin(); }
+
     reverse_iterator rbegin() noexcept { return reverse_iterator(end()); }
-    reverse_iterator rend() noexcept   { return reverse_iterator(begin()); }
-    
+    reverse_iterator rend() noexcept { return reverse_iterator(begin()); }
+
     const_reverse_iterator rbegin() const noexcept { return const_reverse_iterator(end()); }
-    const_reverse_iterator rend() const noexcept   { return const_reverse_iterator(begin()); }
-   
-    const_iterator cbegin() const noexcept { return const_iterator(reinterpret_cast<const T*>(this)); }
-    const_iterator cend() const noexcept   { return begin(); }
-  
+    const_reverse_iterator rend() const noexcept { return const_reverse_iterator(begin()); }
+
+    const_iterator cbegin() const noexcept { return const_iterator(reinterpret_cast<const T *>(this)); }
+    const_iterator cend() const noexcept { return begin(); }
+
     const_reverse_iterator crbegin() const noexcept { return const_reverse_iterator(end()); }
     const_reverse_iterator crend() const noexcept { return const_reverse_iterator(begin()); }
-    
+
     // Operations
-    void fill(const T&) { }    
-    void swap(array&) noexcept { }
+    void fill(const T &) {}
+    void swap(array &) noexcept {}
 
 private:
     T elems[0];
 
 private:
     static void RangeError() {
-        std::out_of_range exception("");
+        out_of_range exception("");
         throw(exception);
-    }      
+    }
 };
 
 // non-member functions
-template<typename T, size_t N >
-bool operator==(const array<T,N>& x, const array<T,N>& y) {
-  return equal( x.cbegin(), x.cend(), y.cbegin());
+template <typename T, size_t N> bool operator==(const array<T, N> &x, const array<T, N> &y) {
+    return equal(x.cbegin(), x.cend(), y.cbegin());
 }
-  
-template<typename T, size_t N >
-bool operator!=(const array<T,N>& x, const array<T,N>& y) {
-  return !(x == y);
-}  
 
-template<typename T, size_t N >
-bool operator<(const array<T,N>& x, const array<T,N>& y) {
-  return lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
-}  
+template <typename T, size_t N> bool operator!=(const array<T, N> &x, const array<T, N> &y) { return !(x == y); }
 
-template<typename T, size_t N >
-bool operator<=(const array<T,N>& x, const array<T,N>& y) {
-  return !(y < x);
-}  
+template <typename T, size_t N> bool operator<(const array<T, N> &x, const array<T, N> &y) {
+    return lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+}
 
-template<typename T, size_t N >
-bool operator>(const array<T,N>& x, const array<T,N>& y) {
-  return y < x;
-}  
+template <typename T, size_t N> bool operator<=(const array<T, N> &x, const array<T, N> &y) { return !(y < x); }
 
-template<typename T, size_t N >
-bool operator>=(const array<T,N>& x, const array<T,N>& y) {
-  return !(x < y);
-}  
+template <typename T, size_t N> bool operator>(const array<T, N> &x, const array<T, N> &y) { return y < x; }
+
+template <typename T, size_t N> bool operator>=(const array<T, N> &x, const array<T, N> &y) { return !(x < y); }
 
 } // namespace ETLSTD

--- a/libstd/include/h/algorithm_minmax.h
+++ b/libstd/include/h/algorithm_minmax.h
@@ -31,112 +31,114 @@
 //  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 //  POSSIBILITY OF SUCH DAMAGE.
 #pragma once
+#include <libstd/include/initializer_list>
 
 namespace ETLSTD {
-  
-template<typename ForwardIt>
-ForwardIt max_element(ForwardIt first, ForwardIt last) {
-  if (first == last) { return last; }
-  ForwardIt largest = first;
-  ++first;
-  for (; first != last; ++first) {
-    if (*largest < *first) { largest = first; }
-  }
-  return largest;
+
+template <typename ForwardIt> ForwardIt max_element(ForwardIt first, ForwardIt last) {
+    if (first == last) {
+        return last;
+    }
+    ForwardIt largest = first;
+    ++first;
+    for (; first != last; ++first) {
+        if (*largest < *first) {
+            largest = first;
+        }
+    }
+    return largest;
 }
 
-template<typename ForwardIt, typename Compare>
-ForwardIt max_element(ForwardIt first, ForwardIt last, Compare comp) {
-  if (first == last) { return last; }
-  ForwardIt largest = first;
-  ++first;
-  for (; first != last; ++first) {
-    if (comp(*largest, *first)) { largest = first; }
-  }
-  return largest;
+template <typename ForwardIt, typename Compare> ForwardIt max_element(ForwardIt first, ForwardIt last, Compare comp) {
+    if (first == last) {
+        return last;
+    }
+    ForwardIt largest = first;
+    ++first;
+    for (; first != last; ++first) {
+        if (comp(*largest, *first)) {
+            largest = first;
+        }
+    }
+    return largest;
 }
 
-template<typename ForwardIt>
-ForwardIt min_element(ForwardIt first, ForwardIt last) {
-  if (first == last) { return last; }
-  ForwardIt smallest = first;
-  ++first;
-  for (; first != last; ++first) {
-      if (*first < *smallest) { smallest = first; }
-  }
-  return smallest;
+template <typename ForwardIt> ForwardIt min_element(ForwardIt first, ForwardIt last) {
+    if (first == last) {
+        return last;
+    }
+    ForwardIt smallest = first;
+    ++first;
+    for (; first != last; ++first) {
+        if (*first < *smallest) {
+            smallest = first;
+        }
+    }
+    return smallest;
 }
 
-template<typename ForwardIt, typename Compare>
-ForwardIt min_element(ForwardIt first, ForwardIt last, Compare comp) {
-  if (first == last) { return last; } 
-  ForwardIt smallest = first;
-  ++first;
-  for (; first != last; ++first) {
-    if (comp(*first, *smallest)) { smallest = first; }
-  }
-  return smallest;
+template <typename ForwardIt, typename Compare> ForwardIt min_element(ForwardIt first, ForwardIt last, Compare comp) {
+    if (first == last) {
+        return last;
+    }
+    ForwardIt smallest = first;
+    ++first;
+    for (; first != last; ++first) {
+        if (comp(*first, *smallest)) {
+            smallest = first;
+        }
+    }
+    return smallest;
 }
 
-template<typename T> 
-constexpr const T& max(const T& a, const T& b ) {
-  return (a < b) ? b : a;
+template <typename T> constexpr const T &max(const T &a, const T &b) { return (a < b) ? b : a; }
+
+template <typename T, typename Compare> constexpr const T &max(const T &a, const T &b, Compare comp) {
+    return (comp(a, b)) ? b : a;
 }
 
-template<typename T, typename Compare>
-constexpr const T& max(const T& a, const T& b, Compare comp) {
-  return (comp(a, b)) ? b : a;
-}  
+template <typename T> constexpr T max(initializer_list<T> ilist) { return *max_element(ilist.begin(), ilist.end()); }
 
-template<typename T>
-constexpr T max( std::initializer_list<T> ilist ) {
-  return *max_element(ilist.begin(), ilist.end());
-}  
-
-template<typename T, typename Compare>
-constexpr T max( std::initializer_list<T> ilist, Compare comp) {
-  return *max_element(ilist.begin(), ilist.end(), comp);
+template <typename T, typename Compare> constexpr T max(initializer_list<T> ilist, Compare comp) {
+    return *max_element(ilist.begin(), ilist.end(), comp);
 }
 
-template<typename  T> 
-constexpr const T& min(const T& a, const T& b) {
-  return (b < a) ? b : a;
-}
-  
-template<typename  T, typename Compare>
-constexpr const T& min(const T& a, const T& b, Compare comp) {
-  return (comp(b, a)) ? b : a;
-}
-  
-template<typename T>
-constexpr T min(std::initializer_list<T> ilist) {
-  return *min_element(ilist.begin(), ilist.end());
-}
-  
-template<typename T, typename Compare>
-constexpr T min(std::initializer_list<T> ilist, Compare comp) {
-  return *min_element(ilist.begin(), ilist.end(), comp);
-}  
+template <typename T> constexpr const T &min(const T &a, const T &b) { return (b < a) ? b : a; }
 
-template<typename InputIt1, typename InputIt2>
-bool lexicographical_compare(InputIt1 first1, InputIt1 last1,
-                             InputIt2 first2, InputIt2 last2) {
-    for (; (first1 != last1) && (first2 != last2); first1++, first2++ ) {
-        if (*first1 < *first2) { return true; }
-        if (*first2 < *first1) { return false; }
+template <typename T, typename Compare> constexpr const T &min(const T &a, const T &b, Compare comp) {
+    return (comp(b, a)) ? b : a;
+}
+
+template <typename T> constexpr T min(initializer_list<T> ilist) { return *min_element(ilist.begin(), ilist.end()); }
+
+template <typename T, typename Compare> constexpr T min(initializer_list<T> ilist, Compare comp) {
+    return *min_element(ilist.begin(), ilist.end(), comp);
+}
+
+template <typename InputIt1, typename InputIt2>
+bool lexicographical_compare(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2) {
+    for (; (first1 != last1) && (first2 != last2); first1++, first2++) {
+        if (*first1 < *first2) {
+            return true;
+        }
+        if (*first2 < *first1) {
+            return false;
+        }
     }
     return (first1 == last1) && (first2 != last2);
 }
 
-template<typename InputIt1, typename InputIt2, typename Compare>
-bool lexicographical_compare(InputIt1 first1, InputIt1 last1,
-                             InputIt2 first2, InputIt2 last2,
-                             Compare comp) {
-    for ( ; (first1 != last1) && (first2 != last2); first1++, first2++ ) {
-        if (comp(*first1, *first2)) { return true; }
-        if (comp(*first2, *first1)) { return false; }
+template <typename InputIt1, typename InputIt2, typename Compare>
+bool lexicographical_compare(InputIt1 first1, InputIt1 last1, InputIt2 first2, InputIt2 last2, Compare comp) {
+    for (; (first1 != last1) && (first2 != last2); first1++, first2++) {
+        if (comp(*first1, *first2)) {
+            return true;
+        }
+        if (comp(*first2, *first1)) {
+            return false;
+        }
     }
     return (first1 == last1) && (first2 != last2);
 }
 
-} // namespace ETLSTD  
+} // namespace ETLSTD

--- a/libstd/include/h/char_traits.h
+++ b/libstd/include/h/char_traits.h
@@ -37,51 +37,61 @@
 
 namespace ETLSTD {
 
-template<typename CharT>
-struct char_traits {
-    using char_type	  = CharT;
-    using int_type    = CharT;
+template <typename CharT> struct char_traits {
+    using char_type = CharT;
+    using int_type = CharT;
 
-    using off_type    = etl::Device::OffType;
-    using pos_type    = etl::Device::OffType;
+    using off_type = etl::Device::OffType;
+    using pos_type = etl::Device::OffType;
 
-    using state_type  = CharT;
+    using state_type = CharT;
 
-    static void assign(char_type& r, const char_type& a) noexcept                       { r = a; }
-    static char_type* assign(char_type* p, std::size_t count, char_type a)              { fill_n(p, count, a); return p; }    
-    static constexpr bool eq(const char_type& c1, const char_type& c2) noexcept         { return c1 == c2; }
-    static constexpr char_type to_char_type(const int_type& i) noexcept                 { return static_cast<char_type>(i); }
-    static constexpr int_type to_int_type(const char_type& c) noexcept                  { return static_cast<int_type>(c); }
-    static constexpr bool eq_int_type(const int_type& a, const int_type& b) noexcept    { return a == b; }
-    static constexpr bool lt(const char_type& c1, const char_type& c2) noexcept         { return c1 < c2; }		
+    static void assign(char_type &r, const char_type &a) noexcept { r = a; }
+    static char_type *assign(char_type *p, std::size_t count, char_type a) {
+        fill_n(p, count, a);
+        return p;
+    }
+    static constexpr bool eq(const char_type &c1, const char_type &c2) noexcept { return c1 == c2; }
+    static constexpr char_type to_char_type(const int_type &i) noexcept { return static_cast<char_type>(i); }
+    static constexpr int_type to_int_type(const char_type &c) noexcept { return static_cast<int_type>(c); }
+    static constexpr bool eq_int_type(const int_type &a, const int_type &b) noexcept { return a == b; }
+    static constexpr bool lt(const char_type &c1, const char_type &c2) noexcept { return c1 < c2; }
 
-    static char_type* move(char_type* s1, const char_type* s2, size_t n)                { memmove(s1, s2, n * sizeof(char_type)); return s1; }
-    static char_type* copy(char_type* s1, const char_type* s2, size_t n)                { memcpy(s1, s2, n * sizeof(char_type)); return s1; }
+    static char_type *move(char_type *s1, const char_type *s2, size_t n) {
+        memmove(s1, s2, n * sizeof(char_type));
+        return s1;
+    }
+    static char_type *copy(char_type *s1, const char_type *s2, size_t n) {
+        memcpy(s1, s2, n * sizeof(char_type));
+        return s1;
+    }
 
-    static int compare(const char_type* s1, const char_type* s2, size_t n) {
-        for (size_t i=0; i<n; ++i) {
-            if (!eq(s1[i], s2[i])) return s1[i]<s2[i] ? -1 : 1;
+    static int compare(const char_type *s1, const char_type *s2, size_t n) {
+        for (size_t i = 0; i < n; ++i) {
+            if (!eq(s1[i], s2[i]))
+                return s1[i] < s2[i] ? -1 : 1;
         }
         return 0;
     }
-  
-    static size_t length(const char_type* s) {
+
+    static constexpr size_t length(const char_type *s) {
         const char_type null_char = char_type();
         size_t nbChars = 0;
         for (; !eq(s[nbChars], null_char); ++nbChars) {}
-	    return nbChars;
+        return nbChars;
     }
 
-    static const char_type* find(const char_type* s, int n, const char_type& c) {
+    static const char_type *find(const char_type *s, int n, const char_type &c) {
         for (; n > 0; ++s, --n) {
-            if (eq(*s, c)) return s;
+            if (eq(*s, c))
+                return s;
         }
         return 0;
     }
-  
-    static char_type eos()                                          { return static_cast<int_type>(0); }
-    static constexpr int_type eof() noexcept                        { return static_cast<int_type>(-1); }
-    static constexpr int_type not_eof(const int_type &i) noexcept   { return !eq_int_type(i, eof()) ? i : 0; }
-};  
 
-}
+    static char_type eos() { return static_cast<int_type>(0); }
+    static constexpr int_type eof() noexcept { return static_cast<int_type>(-1); }
+    static constexpr int_type not_eof(const int_type &i) noexcept { return !eq_int_type(i, eof()) ? i : 0; }
+};
+
+} // namespace ETLSTD

--- a/libstd/include/h/functional_operators.h
+++ b/libstd/include/h/functional_operators.h
@@ -31,268 +31,230 @@
 //  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 //  POSSIBILITY OF SUCH DAMAGE.
 #pragma once
+#include <libstd/include/utility>
 
 namespace ETLSTD {
-  
+
 namespace etlHelper {
-	struct unspecified; // is_transparent type member is specified as *unspecified* in C++14 standard.
+struct unspecified; // is_transparent type member is specified as *unspecified* in C++14 standard.
 }
 
 /// Addition.
 /// @param[in] x,y arguments to be sumed
 /// @return the sum of the two arguments.
-template<typename T = void> struct plus {
-  constexpr T operator()(const T& x, const T& y) const {
-    return x + y;
-  };    
-  using first_argument_type = T;
-  using second_argument_type = T;
-  using result_type = T;
-};  
+template <typename T = void> struct plus {
+    constexpr T operator()(const T &x, const T &y) const { return x + y; };
+    using first_argument_type = T;
+    using second_argument_type = T;
+    using result_type = T;
+};
 
 /// std::plus<void> specialization with member type is_transparent
-template<> struct plus<void> {
-  template<typename T1, typename T2>
-  auto operator()(T1&& x, T2&& y) const -> decltype(std::forward<T1>(x) + std::forward<T2>(y)) {
-    return std::forward<T1>(x) + std::forward<T2>(y);
-    typedef etlHelper::unspecified is_transparent __attribute__((__unused__));
-  }    
+template <> struct plus<void> {
+    template <typename T1, typename T2> auto operator()(T1 &&x, T2 &&y) const -> decltype(forward<T1>(x) + forward<T2>(y)) {
+        return forward<T1>(x) + forward<T2>(y);
+        typedef etlHelper::unspecified is_transparent __attribute__((__unused__));
+    }
 };
 
 /// Substraction.
 /// @param[in] x,y arguments to be substracted
 /// @return the difference of the two arguments.
-template<typename T = void> struct minus {
-  constexpr T operator()(const T& x, const T& y) const {
-    return x - y;
-  };    
-  using first_argument_type = T;
-  using second_argument_type = T;
-  using result_type = T;
-};  
+template <typename T = void> struct minus {
+    constexpr T operator()(const T &x, const T &y) const { return x - y; };
+    using first_argument_type = T;
+    using second_argument_type = T;
+    using result_type = T;
+};
 
 /// std::minus<void> specialization with member type is_transparent
-template<> struct minus<void> {
-  template<typename T1, typename T2>
-  auto operator()(T1&& x, T2&& y) const -> decltype(std::forward<T1>(x) - std::forward<T2>(y)) {
-    return std::forward<T1>(x) - std::forward<T2>(y);
-    typedef etlHelper::unspecified is_transparent __attribute__((__unused__));
-  }    
+template <> struct minus<void> {
+    template <typename T1, typename T2> auto operator()(T1 &&x, T2 &&y) const -> decltype(forward<T1>(x) - forward<T2>(y)) {
+        return forward<T1>(x) - forward<T2>(y);
+        typedef etlHelper::unspecified is_transparent __attribute__((__unused__));
+    }
 };
 
 /// Division.
 /// @param[in] x,y arguments to divide
 /// @return the result of the division of the two arguments.
-template<typename T = void> struct divides {
-  constexpr T operator()(const T& x, const T& y) const {
-    return x / y;
-  };    
-  using first_argument_type = T;
-  using second_argument_type = T;
-  using result_type = T;
-};  
+template <typename T = void> struct divides {
+    constexpr T operator()(const T &x, const T &y) const { return x / y; };
+    using first_argument_type = T;
+    using second_argument_type = T;
+    using result_type = T;
+};
 
 /// std::divides<void> specialization with member type is_transparent
-template<> struct divides<void> {
-  template<typename T1, typename T2>
-  auto operator()(T1&& x, T2&& y) const -> decltype(std::forward<T1>(x) / std::forward<T2>(y)) {
-    return std::forward<T1>(x) / std::forward<T2>(y);
-    typedef etlHelper::unspecified is_transparent  __attribute__((__unused__));
-  }    
+template <> struct divides<void> {
+    template <typename T1, typename T2> auto operator()(T1 &&x, T2 &&y) const -> decltype(forward<T1>(x) / forward<T2>(y)) {
+        return forward<T1>(x) / forward<T2>(y);
+        typedef etlHelper::unspecified is_transparent __attribute__((__unused__));
+    }
 };
 
 /// Multiplication.
 /// @param[in] x,y arguments to multiply
 /// @return the product of the two arguments.
-template<typename T = void> struct multiplies{
-  constexpr T operator()(const T& x, const T& y) const {
-    return x * y;
-  };    
-  using first_argument_type = T;
-  using second_argument_type = T;
-  using result_type = T;
-};  
+template <typename T = void> struct multiplies {
+    constexpr T operator()(const T &x, const T &y) const { return x * y; };
+    using first_argument_type = T;
+    using second_argument_type = T;
+    using result_type = T;
+};
 
 /// std::<void> specialization with member type is_transparent
-template<> struct multiplies<void> {
-  template<typename T1, typename T2>
-  auto operator()(T1&& x, T2&& y) const -> decltype(std::forward<T1>(x) * std::forward<T2>(y)) {
-    return std::forward<T1>(x) * std::forward<T2>(y);
-    typedef etlHelper::unspecified is_transparent  __attribute__((__unused__));
-  }    
+template <> struct multiplies<void> {
+    template <typename T1, typename T2> auto operator()(T1 &&x, T2 &&y) const -> decltype(forward<T1>(x) * forward<T2>(y)) {
+        return forward<T1>(x) * forward<T2>(y);
+        typedef etlHelper::unspecified is_transparent __attribute__((__unused__));
+    }
 };
 
 /// Modulus.
 /// @param[in] x,y arguments
 /// @return remainder of division of the two arguments.
-template<typename T = void> struct modulus {
-  constexpr T operator()(const T& x, const T& y) const {
-    return x % y;
-  };    
-  using first_argument_type = T;
-  using second_argument_type = T;
-  using result_type = T;
-};  
+template <typename T = void> struct modulus {
+    constexpr T operator()(const T &x, const T &y) const { return x % y; };
+    using first_argument_type = T;
+    using second_argument_type = T;
+    using result_type = T;
+};
 
 /// std::<void> specialization with member type is_transparent
-template<> struct modulus<void> {
-  template<typename T1, typename T2>
-  auto operator()(T1&& x, T2&& y) const -> decltype(std::forward<T1>(x) % std::forward<T2>(y)) {
-    return std::forward<T1>(x) % std::forward<T2>(y);
-    typedef etlHelper::unspecified is_transparent  __attribute__((__unused__));
-  }    
+template <> struct modulus<void> {
+    template <typename T1, typename T2> auto operator()(T1 &&x, T2 &&y) const -> decltype(forward<T1>(x) % forward<T2>(y)) {
+        return forward<T1>(x) % forward<T2>(y);
+        typedef etlHelper::unspecified is_transparent __attribute__((__unused__));
+    }
 };
 
-template<typename T = void> struct negate {
-  constexpr T operator()(const T& x) const {
-    return -x;
-  };    
-};  
-
-template<> struct negate<void> {
-  template<typename T>
-  auto operator()(T&& x) const -> decltype(-std::forward<T>(x)) {
-    return -std::forward<T>(x);
-    typedef etlHelper::unspecified is_transparent  __attribute__((__unused__));
-  }    
+template <typename T = void> struct negate {
+    constexpr T operator()(const T &x) const { return -x; };
 };
 
-template<typename T = void> struct less {
-  constexpr bool operator()(const T& x, const T& y) const {
-    return x < y;
-  };    
-  using first_argument_type = T;
-  using second_argument_type = T;
-  using result_type = bool;
-};  
+template <> struct negate<void> {
+    template <typename T> auto operator()(T &&x) const -> decltype(-forward<T>(x)) {
+        return -forward<T>(x);
+        typedef etlHelper::unspecified is_transparent __attribute__((__unused__));
+    }
+};
+
+template <typename T = void> struct less {
+    constexpr bool operator()(const T &x, const T &y) const { return x < y; };
+    using first_argument_type = T;
+    using second_argument_type = T;
+    using result_type = bool;
+};
 
 /// std::less<void> specialization with member type is_transparent
-template<> struct less<void> {
-  template<typename T1, typename T2>
-  auto operator()(T1&& x, T2&& y) const -> decltype(std::forward<T1>(x) < std::forward<T2>(y)) {
-    return std::forward<T1>(x) < std::forward<T2>(y);
-    typedef etlHelper::unspecified is_transparent  __attribute__((__unused__));
-  }    
+template <> struct less<void> {
+    template <typename T1, typename T2> auto operator()(T1 &&x, T2 &&y) const -> decltype(forward<T1>(x) < forward<T2>(y)) {
+        return forward<T1>(x) < forward<T2>(y);
+        typedef etlHelper::unspecified is_transparent __attribute__((__unused__));
+    }
 };
-
 
 /// Checks whether x is equal to y.
 /// @param[in] x,y values to compare
 /// @return true if x == y, false otherwise.
-template<typename T = void> struct equal_to {
-  constexpr bool operator()(const T& x, const T& y) const {
-    return x == y;
-  };    
-  using first_argument_type = T;
-  using second_argument_type = T;
-  using result_type = bool;
-};  
+template <typename T = void> struct equal_to {
+    constexpr bool operator()(const T &x, const T &y) const { return x == y; };
+    using first_argument_type = T;
+    using second_argument_type = T;
+    using result_type = bool;
+};
 
 /// std::equal_to<void> specialization with member type is_transparent
-template<> struct equal_to<void> {
-  template<typename T1, typename T2>
-  auto operator()(T1&& x, T2&& y) const -> decltype(std::forward<T1>(x) == std::forward<T2>(y)) {
-    return std::forward<T1>(x) == std::forward<T2>(y);
-    typedef etlHelper::unspecified is_transparent  __attribute__((__unused__));
-  }    
+template <> struct equal_to<void> {
+    template <typename T1, typename T2> auto operator()(T1 &&x, T2 &&y) const -> decltype(forward<T1>(x) == forward<T2>(y)) {
+        return forward<T1>(x) == forward<T2>(y);
+        typedef etlHelper::unspecified is_transparent __attribute__((__unused__));
+    }
 };
 
 /// Checks whether x is different from y.
 /// @param[in] x,y values to compare
 /// @return true if x != y, false otherwise.
-template<typename T = void> struct not_equal_to {
-  constexpr bool operator()(const T& x, const T& y) const {
-    return x != y;
-  };    
-  using first_argument_type = T;
-  using second_argument_type = T;
-  using result_type = bool;
-};  
+template <typename T = void> struct not_equal_to {
+    constexpr bool operator()(const T &x, const T &y) const { return x != y; };
+    using first_argument_type = T;
+    using second_argument_type = T;
+    using result_type = bool;
+};
 
 /// std::not_equal_to<void> specialization with member type is_transparent
-template<> struct not_equal_to<void> {
-  template<typename T1, typename T2>
-  auto operator()(T1&& x, T2&& y) const -> decltype(std::forward<T1>(x) != std::forward<T2>(y)) {
-    return std::forward<T1>(x) != std::forward<T2>(y);
-    typedef etlHelper::unspecified is_transparent  __attribute__((__unused__));
-  }    
+template <> struct not_equal_to<void> {
+    template <typename T1, typename T2> auto operator()(T1 &&x, T2 &&y) const -> decltype(forward<T1>(x) != forward<T2>(y)) {
+        return forward<T1>(x) != forward<T2>(y);
+        typedef etlHelper::unspecified is_transparent __attribute__((__unused__));
+    }
 };
 
 /// Checks whether x is greater than y.
 /// @param[in] x,y values to compare
 /// @return true if x > y, false otherwise.
-template<typename T = void> struct greater {
-  constexpr bool operator()(const T& x, const T& y) const {
-    return x > y;
-  };    
-  using first_argument_type = T;
-  using second_argument_type = T;
-  using result_type = bool;
-};  
+template <typename T = void> struct greater {
+    constexpr bool operator()(const T &x, const T &y) const { return x > y; };
+    using first_argument_type = T;
+    using second_argument_type = T;
+    using result_type = bool;
+};
 
 /// std::greater<void> specialization with member type is_transparent
-template<> struct greater<void> {
-  template<typename T1, typename T2>
-  auto operator()(T1&& x, T2&& y) const -> decltype(std::forward<T1>(x) > std::forward<T2>(y)) {
-    return std::forward<T1>(x) > std::forward<T2>(y);
-    typedef etlHelper::unspecified is_transparent  __attribute__((__unused__));
-  }    
+template <> struct greater<void> {
+    template <typename T1, typename T2> auto operator()(T1 &&x, T2 &&y) const -> decltype(forward<T1>(x) > forward<T2>(y)) {
+        return forward<T1>(x) > forward<T2>(y);
+        typedef etlHelper::unspecified is_transparent __attribute__((__unused__));
+    }
 };
 
 /// Checks whether x is greater than or equal to y.
 /// @param[in] x,y values to compare
 /// @return true if x >= y, false otherwise.
-template<typename T = void> struct greater_equal {
-  constexpr bool operator()(const T& x, const T& y) const {
-    return x >= y;
-  };    
-  using first_argument_type = T;
-  using second_argument_type = T;
-  using result_type = bool;
-};  
+template <typename T = void> struct greater_equal {
+    constexpr bool operator()(const T &x, const T &y) const { return x >= y; };
+    using first_argument_type = T;
+    using second_argument_type = T;
+    using result_type = bool;
+};
 
 /// std::greater_equal<void> specialization with member type is_transparent
-template<> struct greater_equal<void> {
-  template<typename T1, typename T2>
-  auto operator()(T1&& x, T2&& y) const -> decltype(std::forward<T1>(x) >= std::forward<T2>(y)) {
-    return std::forward<T1>(x) >= std::forward<T2>(y);
-    typedef etlHelper::unspecified is_transparent  __attribute__((__unused__));
-  }    
+template <> struct greater_equal<void> {
+    template <typename T1, typename T2> auto operator()(T1 &&x, T2 &&y) const -> decltype(forward<T1>(x) >= forward<T2>(y)) {
+        return forward<T1>(x) >= forward<T2>(y);
+        typedef etlHelper::unspecified is_transparent __attribute__((__unused__));
+    }
 };
 
 /// Checks whether x is less than or equal to y.
 /// @param[in] x,y values to compare
 /// @return true if x <= y, false otherwise.
-template<typename T = void> struct less_equal {
-  constexpr bool operator()(const T& x, const T& y) const {
-    return x <= y;
-  };    
-  using first_argument_type = T;
-  using second_argument_type = T;
-  using result_type = bool;
-};  
-
-/// std::less_equal<void> specialization with member type is_transparent
-template<> struct less_equal<void> {
-  template<typename T1, typename T2>
-  auto operator()(T1&& x, T2&& y) const -> decltype(std::forward<T1>(x) <= std::forward<T2>(y)) {
-    return std::forward<T1>(x) <= std::forward<T2>(y);
-    typedef etlHelper::unspecified is_transparent  __attribute__((__unused__));
-  }    
+template <typename T = void> struct less_equal {
+    constexpr bool operator()(const T &x, const T &y) const { return x <= y; };
+    using first_argument_type = T;
+    using second_argument_type = T;
+    using result_type = bool;
 };
 
-template<typename T = void>
-struct bit_not {
-  using result_type   = T;
-  using argument_type = T;
-  constexpr T operator()(const T& arg) const { return ~arg; }
+/// std::less_equal<void> specialization with member type is_transparent
+template <> struct less_equal<void> {
+    template <typename T1, typename T2> auto operator()(T1 &&x, T2 &&y) const -> decltype(forward<T1>(x) <= forward<T2>(y)) {
+        return forward<T1>(x) <= forward<T2>(y);
+        typedef etlHelper::unspecified is_transparent __attribute__((__unused__));
+    }
+};
+
+template <typename T = void> struct bit_not {
+    using result_type = T;
+    using argument_type = T;
+    constexpr T operator()(const T &arg) const { return ~arg; }
 };
 
 #ifdef __GNUG__
-template<> struct bit_not<void> {
-  template<typename T>
-  constexpr auto operator()(T&& arg) const -> decltype(~std::forward<T>(arg));
-  typedef etlHelper::unspecified is_transparent  __attribute__((__unused__));
+template <> struct bit_not<void> {
+    template <typename T> constexpr auto operator()(T &&arg) const -> decltype(~forward<T>(arg));
+    typedef etlHelper::unspecified is_transparent __attribute__((__unused__));
 };
 #endif
 

--- a/libstd/include/memory
+++ b/libstd/include/memory
@@ -41,114 +41,115 @@
 namespace ETLSTD {
 namespace etlHelper {
 // addressof helpers taken from Boost library
-template<typename T> struct addressof_ref {
-    T & v_;
-    addressof_ref(T & v) : v_(v) {}
-    operator T& () const { return v_; }
+template <typename T> struct addressof_ref {
+    T &v_;
+    addressof_ref(T &v) : v_(v) {}
+    operator T &() const { return v_; }
 
 private:
-    addressof_ref & operator=(const addressof_ref &);
+    addressof_ref &operator=(const addressof_ref &);
 };
 
-template<typename T> struct addressof_impl {
-    static T * f(T & v, long) {
-        return reinterpret_cast<T*>(&const_cast<char&>(reinterpret_cast<const volatile char &>(v)));
-    }
-    static T * f(T * v, int) { return v; }
+template <typename T> struct addressof_impl {
+    static T *f(T &v, long) { return reinterpret_cast<T *>(&const_cast<char &>(reinterpret_cast<const volatile char &>(v))); }
+    static T *f(T *v, int) { return v; }
 };
-} //namespace etlHelper
+} // namespace etlHelper
 
-template<typename T>
-class allocator {
+template <typename T> class allocator {
 public:
     using value_type = T;
     using propagate_on_container_move_assignment = true_type;
     using is_always_equal = true_type;
 
 public:
-    template<typename U> struct rebind { using other = allocator<U>; };
+    template <typename U> struct rebind {
+        using other = allocator<U>;
+    };
 
     allocator() noexcept {}
-    allocator(const allocator&) noexcept {};
-    template<typename T2> allocator(const allocator<T2>&) noexcept {};
+    allocator(const allocator &) noexcept {};
+    template <typename T2> allocator(const allocator<T2> &) noexcept {};
     ~allocator() {};
 
-    T* allocate(size_t n) { return reinterpret_cast<T*>(::operator new(n * sizeof(T))); }
-    void deallocate(T* p, size_t) { ::operator delete(p); }
-    bool operator==(allocator const&) { return true; }
-    bool operator!=(allocator const& a) { return !operator==(a); }
+    T *allocate(size_t n) { return reinterpret_cast<T *>(::operator new(n * sizeof(T))); }
+    void deallocate(T *p, size_t) { ::operator delete(p); }
+    bool operator==(allocator const &) { return true; }
+    bool operator!=(allocator const &a) { return !operator==(a); }
 };
 
 namespace etlHelper {
-template<typename T> using hasDiffT = decltype(T::difference_type);
-template<typename T> using hasRebind = typename T::template rebind<T>;
-template<typename T> using hasPointer = decltype(T::pointer);
-template<typename T> using hasConstPointer = decltype(T::const_pointer);
-template<typename T> using hasDifferenceType = decltype(T::difference_type);
-template<typename T> using hasSizeType = decltype(T::size_type);
-template<typename T> using hasVoidPointer = decltype(T::void_pointer);
-template<typename T> using hasConstVoidPointer = decltype(T::const_void_pointer);
-template<typename T> using hasPropagateCopy = decltype(T::propagate_on_container_copy_assignment);
-template<typename T> using hasPropagateMove = decltype(T::propagate_on_container_move_assignment);
-template<typename T> using hasPropagateSwap = decltype(T::propagate_on_container_swap);
-template<typename T> using hasIsAlwaysEqual = decltype(T::is_always_equal);
-template<typename T> using hasConstruct = decltype(T::construct);
+template <typename T> using hasDiffT = decltype(T::difference_type);
+template <typename T> using hasRebind = typename T::template rebind<T>;
+template <typename T> using hasPointer = decltype(T::pointer);
+template <typename T> using hasConstPointer = decltype(T::const_pointer);
+template <typename T> using hasDifferenceType = decltype(T::difference_type);
+template <typename T> using hasSizeType = decltype(T::size_type);
+template <typename T> using hasVoidPointer = decltype(T::void_pointer);
+template <typename T> using hasConstVoidPointer = decltype(T::const_void_pointer);
+template <typename T> using hasPropagateCopy = decltype(T::propagate_on_container_copy_assignment);
+template <typename T> using hasPropagateMove = decltype(T::propagate_on_container_move_assignment);
+template <typename T> using hasPropagateSwap = decltype(T::propagate_on_container_swap);
+template <typename T> using hasIsAlwaysEqual = decltype(T::is_always_equal);
+template <typename T> using hasConstruct = decltype(T::construct);
 } // namespace etlHelper
 
-template<typename Ptr>
-struct pointer_traits {
+template <typename Ptr> struct pointer_traits {
     using pointer = Ptr;
     using element_type = typename Ptr::element_type;
     using difference_type = detected_or_t<ptrdiff_t, etlHelper::hasDiffT, Ptr>;
-    template<typename U> using rebind = detected_or_t<U*, etlHelper::hasRebind, U>;
+    template <typename U> using rebind = detected_or_t<U *, etlHelper::hasRebind, U>;
 };
 
-template<typename T>
-struct pointer_traits<T*> {
-    using pointer = T*;
+template <typename T> struct pointer_traits<T *> {
+    using pointer = T *;
     using element_type = T;
     using difference_type = ptrdiff_t;
-    template <typename U> using rebind = U*;
+    template <typename U> using rebind = U *;
 };
 
-
-template<typename Alloc>
-struct allocator_traits {
+template <typename Alloc> struct allocator_traits {
     using value_type = typename Alloc::value_type;
     using allocator_type = Alloc;
-    //using pointer = detected_or_t<value_type*, etlHelper::hasPointer, allocator_type>;
-    using pointer = value_type*;
-    using const_pointer = detected_or_t<typename pointer_traits<pointer>::template rebind<const value_type>, etlHelper::hasConstPointer, allocator_type>;
-    using void_pointer = detected_or_t<typename pointer_traits<pointer>::template rebind<void>, etlHelper::hasVoidPointer, allocator_type>;
-    using const_void_pointer = detected_or_t<typename pointer_traits<pointer>::template rebind<const void>, etlHelper::hasConstVoidPointer, allocator_type>;
-    using difference_type = detected_or_t<typename pointer_traits<pointer>::difference_type, etlHelper::hasDifferenceType, allocator_type>;
-    using size_type = detected_or_t < make_unsigned_t<difference_type>, etlHelper::hasSizeType, allocator_type>;
+    // using pointer = detected_or_t<value_type*, etlHelper::hasPointer, allocator_type>;
+    using pointer = value_type *;
+    using const_pointer = detected_or_t<typename pointer_traits<pointer>::template rebind<const value_type>,
+                                        etlHelper::hasConstPointer, allocator_type>;
+    using void_pointer =
+        detected_or_t<typename pointer_traits<pointer>::template rebind<void>, etlHelper::hasVoidPointer, allocator_type>;
+    using const_void_pointer = detected_or_t<typename pointer_traits<pointer>::template rebind<const void>,
+                                             etlHelper::hasConstVoidPointer, allocator_type>;
+    using difference_type =
+        detected_or_t<typename pointer_traits<pointer>::difference_type, etlHelper::hasDifferenceType, allocator_type>;
+    using size_type = detected_or_t<make_unsigned_t<difference_type>, etlHelper::hasSizeType, allocator_type>;
     using propagate_on_container_copy_assignment = detected_or_t<false_type, etlHelper::hasPropagateCopy, allocator_type>;
     using propagate_on_container_move_assignment = detected_or_t<false_type, etlHelper::hasPropagateMove, allocator_type>;
     using propagate_on_container_swap = detected_or_t<false_type, etlHelper::hasPropagateSwap, allocator_type>;
     using is_always_equal = detected_or_t<typename is_empty<allocator_type>::type, etlHelper::hasIsAlwaysEqual, allocator_type>;
 
-
-    template<typename T, typename... Args, typename DummyInt = uint8_t, enable_if_t<!is_detected_v<etlHelper::hasConstruct, allocator_type>, DummyInt> = 0>
-    static void construct(Alloc& a, T* p, Args&&... args) {
-        ::new (static_cast<void*>(p)) T(std::forward<Args>(args)...);
+    template <typename T, typename... Args, typename DummyInt = uint8_t,
+              enable_if_t<!is_detected_v<etlHelper::hasConstruct, allocator_type>, DummyInt> = 0>
+    static void construct(Alloc &a, T *p, Args &&...args) {
+        ::new (static_cast<void *>(p)) T(forward<Args>(args)...);
     }
 
-    template<typename T, typename... Args, typename DummyInt = uint8_t, enable_if_t<is_detected_v<etlHelper::hasConstruct, allocator_type>, DummyInt> = 0>
-    static void construct(Alloc& a, T* p, Args&&... args) {
+    template <typename T, typename... Args, typename DummyInt = uint8_t,
+              enable_if_t<is_detected_v<etlHelper::hasConstruct, allocator_type>, DummyInt> = 0>
+    static void construct(Alloc &a, T *p, Args &&...args) {
         allocator_type::construct(p, forward<Args>(args)...);
     }
 };
 
-template<typename T> constexpr T* addressof(T& arg) {
+template <typename T> constexpr T *addressof(T &arg) {
     return etlHelper::addressof_impl<T>::f(etlHelper::addressof_ref<T>(arg), 0);
 }
 
 namespace etlHelper {
 class refCounter {
     long count;
+
 public:
-    refCounter() : count(1) { }
+    refCounter() : count(1) {}
     virtual ~refCounter() = default;
 
     void inc() { ++count; }
@@ -156,54 +157,59 @@ public:
     long use_count() const { return count; }
 };
 
-template<typename T> struct refCountAndPointer : refCounter {
-    T* pointee;
-    explicit refCountAndPointer(T* p) : pointee(p) { }
+template <typename T> struct refCountAndPointer : refCounter {
+    T *pointee;
+    explicit refCountAndPointer(T *p) : pointee(p) {}
     ~refCountAndPointer() override { delete pointee; }
 };
 
-template<typename T> struct refCountAndObject : refCounter {
+template <typename T> struct refCountAndObject : refCounter {
     T object;
-    template<typename ... Args> refCountAndObject(Args && ...args) : object(args...) { }
+    template <typename... Args> refCountAndObject(Args &&...args) : object(args...) {}
 };
-} //namespace etlHelper
+} // namespace etlHelper
 
-template<typename T>
-class shared_ptr {
+template <typename T> class shared_ptr {
 public:
     using element_type = remove_extent_t<T>;
 
     constexpr shared_ptr() : pointee(nullptr), counter(nullptr) {}
     constexpr shared_ptr(std::nullptr_t) : pointee(nullptr), counter(nullptr) {}
-    explicit shared_ptr(T* p) { createCounter(p); }
-    template <typename U> shared_ptr(const shared_ptr<U>& ptr) { *this = ptr; }
-    shared_ptr(const shared_ptr& ptr) : counter(ptr.counter), pointee(ptr.pointee) { if (use_count() > 0) counter->inc(); }
-    ~shared_ptr()       { release(); }
+    explicit shared_ptr(T *p) { createCounter(p); }
+    template <typename U> shared_ptr(const shared_ptr<U> &ptr) { *this = ptr; }
+    shared_ptr(const shared_ptr &ptr) : counter(ptr.counter), pointee(ptr.pointee) {
+        if (use_count() > 0)
+            counter->inc();
+    }
+    ~shared_ptr() { release(); }
 
-    void reset()        { release(); }
-    void reset(T* p)    { release(); createCounter(p); }
+    void reset() { release(); }
+    void reset(T *p) {
+        release();
+        createCounter(p);
+    }
 
-    shared_ptr& operator=(const shared_ptr& rhs) { 
+    shared_ptr &operator=(const shared_ptr &rhs) {
         release();
         pointee = rhs.pointee;
         counter = rhs.counter;
         return *this;
     }
 
-    void swap(shared_ptr& lhs) {
-        std::swap(pointee, lhs.pointee);
-        std::swap(counter, lhs.counter);
+    void swap(shared_ptr &lhs) {
+        ETLSTD::swap(pointee, lhs.pointee);
+        ETLSTD::swap(counter, lhs.counter);
     }
 
-    operator bool()     const { return pointee != nullptr; }
-    bool unique()       const { return 1 == use_count(); }
-    long use_count()    const { return counter ? counter->use_count() : 0; }
-    T& operator*()      const { return *pointee; }
-    T* operator->()     const { return pointee; }
-    T* get(void)        const { return pointee; }
+    operator bool() const { return pointee != nullptr; }
+    bool unique() const { return 1 == use_count(); }
+    long use_count() const { return counter ? counter->use_count() : 0; }
+    T &operator*() const { return *pointee; }
+    T *operator->() const { return pointee; }
+    T *get(void) const { return pointee; }
 
 private:
-    void createCounter(T* p) {
+    void createCounter(T *p) {
         auto tmp = new etlHelper::refCountAndPointer<T>(p);
         pointee = tmp->pointee;
         counter = tmp;
@@ -221,24 +227,31 @@ private:
     }
 
 private:
-    template<typename U> friend class shared_ptr;
-    template<typename T1, typename... Args> friend shared_ptr<T1> make_shared(Args&&... args);
-    T*                      pointee;
-    etlHelper::refCounter*  counter;
+    template <typename U> friend class shared_ptr;
+    template <typename T1, typename... Args> friend shared_ptr<T1> make_shared(Args &&...args);
+    T *pointee;
+    etlHelper::refCounter *counter;
 };
 
-
-template<typename T, typename U> bool operator==(const shared_ptr<T>& l, const shared_ptr<U>& r) { return (l.get() == r.get()); }
-template<typename T, typename U> bool operator!=(const shared_ptr<T>& l, const shared_ptr<U>& r) { return (l.get() != r.get()); }
-template<typename T, typename U> bool operator<=(const shared_ptr<T>& l, const shared_ptr<U>& r) { return (l.get() <= r.get()); }
-template<typename T, typename U> bool operator<(const shared_ptr<T>& l, const shared_ptr<U>& r) { return (l.get() < r.get()); }
-template<typename T, typename U> bool operator>=(const shared_ptr<T>& l, const shared_ptr<U>& r) { return (l.get() >= r.get()); }
-template<typename T, typename U> bool operator>(const shared_ptr<T>& l, const shared_ptr<U>& r) { return (l.get() > r.get()); }
-template<typename T, typename U>shared_ptr<T> static_pointer_cast(const shared_ptr<U>& ptr) {
-    return shared_ptr<T>(ptr, static_cast<typename shared_ptr<T>::element_type*>(ptr.get()));
+template <typename T, typename U> bool operator==(const shared_ptr<T> &l, const shared_ptr<U> &r) {
+    return (l.get() == r.get());
+}
+template <typename T, typename U> bool operator!=(const shared_ptr<T> &l, const shared_ptr<U> &r) {
+    return (l.get() != r.get());
+}
+template <typename T, typename U> bool operator<=(const shared_ptr<T> &l, const shared_ptr<U> &r) {
+    return (l.get() <= r.get());
+}
+template <typename T, typename U> bool operator<(const shared_ptr<T> &l, const shared_ptr<U> &r) { return (l.get() < r.get()); }
+template <typename T, typename U> bool operator>=(const shared_ptr<T> &l, const shared_ptr<U> &r) {
+    return (l.get() >= r.get());
+}
+template <typename T, typename U> bool operator>(const shared_ptr<T> &l, const shared_ptr<U> &r) { return (l.get() > r.get()); }
+template <typename T, typename U> shared_ptr<T> static_pointer_cast(const shared_ptr<U> &ptr) {
+    return shared_ptr<T>(ptr, static_cast<typename shared_ptr<T>::element_type *>(ptr.get()));
 }
 
-template<typename T, typename ... Args> shared_ptr<T> make_shared(Args && ... args) {
+template <typename T, typename... Args> shared_ptr<T> make_shared(Args &&...args) {
     shared_ptr<T> ptr;
     auto tmp = new etlHelper::refCountAndObject<T>(args...);
     ptr.pointee = &tmp->object;

--- a/libstd/include/string_view
+++ b/libstd/include/string_view
@@ -183,7 +183,7 @@ public:
     }
 
     constexpr bool starts_with(basic_string_view x) const noexcept {
-        return size() >= x.size() && compare(0, x.size(), x) == 0;
+        return size() >= x.size() && Traits::compare(data(), x.data(), x.size()) == 0;
     }
 
     constexpr bool starts_with(CharT x) const noexcept { return starts_with(basic_string_view(&x, 1)); }

--- a/test/libstd/bitset.cpp
+++ b/test/libstd/bitset.cpp
@@ -38,7 +38,7 @@
 
 using namespace ETLSTD;
 
-SCENARIO("bitset") {
+SCENARIO("bitset", "[libstd][bitset]") {
     
     bitset<17> bits0;
     REQUIRE(bits0.size() == 17);

--- a/test/libstd/chrono.cpp
+++ b/test/libstd/chrono.cpp
@@ -36,7 +36,7 @@
 #define ETLSTD etlstd
 #include <libstd/include/chrono>
 
-SCENARIO("std::chrono") {
+SCENARIO("std::chrono", "[libstd][chrono]") {
     using namespace ETLSTD::chrono;
     using namespace ETLSTD::chrono_literals;
     auto dur_ns = 2153123456ns;

--- a/test/libstd/limits.cpp
+++ b/test/libstd/limits.cpp
@@ -40,7 +40,7 @@
 using namespace ETLSTD;
 using ETLSTD::size_t;
 
-SCENARIO("std::numeric_limits") {
+SCENARIO("std::numeric_limits", "[libstd][limits]") {
 
     auto r1 = numeric_limits<uint32_t>::is_signed;
     REQUIRE(r1 == false);

--- a/test/libstd/memory.cpp
+++ b/test/libstd/memory.cpp
@@ -55,7 +55,7 @@ public:
 uint8_t MyClass::instances = 0;
 //using namespace etlTest::std;
 
-SCENARIO("std::unique_ptr") {
+SCENARIO("std::unique_ptr", "[libstd][memory]") {
     GIVEN("0 class instances") {
         MyClass::instances = 0;
         WHEN("a unique_ptr is created") {
@@ -71,7 +71,7 @@ SCENARIO("std::unique_ptr") {
     }
 }
 
-SCENARIO("std::shared_ptr") {
+SCENARIO("std::shared_ptr", "[libstd][memory]") {
     GIVEN("A shared_ptr constructed by make_shared") {
         MyClass::instances = 0;
         auto obj = ETLSTD::make_shared<MyClass>(123456);

--- a/test/libstd/queue.cpp
+++ b/test/libstd/queue.cpp
@@ -65,7 +65,7 @@ protected:
     size_type contSize;
 };
 
-SCENARIO("Queue") {
+SCENARIO("Queue", "[libstd][queue]") {
     using Fifo = ETLSTD::queue<uint8_t, SequenceContainerMock>;
     GIVEN("An empty Fifo") {
         Fifo fifo;

--- a/test/libstd/string_view.cpp
+++ b/test/libstd/string_view.cpp
@@ -39,7 +39,7 @@
 
 using namespace ETLSTD;
 
-SCENARIO("Test of std::string_view") {
+SCENARIO("Test of std::string_view", "[libstd][string_view]") {
     const char* str = "std::string_view";
     string_view v = str;
     REQUIRE(v.size() == 16);
@@ -55,7 +55,7 @@ SCENARIO("Test of std::string_view") {
 
 }
 
-SCENARIO("std::string_view find functions") {
+SCENARIO("std::string_view find functions", "[libstd][string_view]") {
     string_view v("original string with five words.");
 
     REQUIRE(v.find("string") == 9);
@@ -72,7 +72,7 @@ SCENARIO("std::string_view find functions") {
 }
 
 
-SCENARIO("std::string_view rfind functions") {
+SCENARIO("std::string_view rfind functions", "[libstd][string_view]") {
     string_view v("String with multiple 'with' words within.");
 
     REQUIRE(v.find("with") == 7);
@@ -86,7 +86,7 @@ SCENARIO("std::string_view rfind functions") {
     REQUIRE(v.find(with) == 21);
 }
 
-SCENARIO("std::string_view find_first_of functions") {
+SCENARIO("std::string_view find_first_of functions", "[libstd][string_view]") {
     string_view v("String with multiple 'with' words within.");
 
     REQUIRE(v.find_first_of("mdkz") == 12);
@@ -96,7 +96,7 @@ SCENARIO("std::string_view find_first_of functions") {
     REQUIRE(v.find_first_of(tiple, 2) == 3);
 }
 
-SCENARIO("std::string_view find_last_of functions") {
+SCENARIO("std::string_view find_last_of functions", "[libstd][string_view]") {
     string_view v("String with multiple 'with' words within.");
 
     REQUIRE(v.find_last_of("mdkz") == 31);
@@ -106,7 +106,7 @@ SCENARIO("std::string_view find_last_of functions") {
     REQUIRE(v.find_last_of(tiple, 34) == 24);
 }
 
-SCENARIO("std::string_view find_first_not_of functions") {
+SCENARIO("std::string_view find_first_not_of functions", "[libstd][string_view]") {
     string_view v("String with multiple 'with' words within.");
 
     REQUIRE(v.find_first_not_of("String wh") == 12);
@@ -114,14 +114,14 @@ SCENARIO("std::string_view find_first_not_of functions") {
     REQUIRE(v.find_first_not_of('S') == 1);
 }
 
-SCENARIO("std::string_view find_last_not_of functions") {
+SCENARIO("std::string_view find_last_not_of functions", "[libstd][string_view]") {
     string_view v("String with multiple 'with' words within.");
 
     REQUIRE(v.find_last_not_of(". withn") == 32);
     REQUIRE(v.find_last_not_of('.') == v.size() - 2);
 }
 
-SCENARIO("std::string_view comparisons") {
+SCENARIO("std::string_view comparisons", "[libstd][string_view]") {
     auto s1 { "String1"sv };
     auto s2 = "String2"sv;
     string_view s3("String1 longer");
@@ -139,7 +139,7 @@ SCENARIO("std::string_view comparisons") {
 }
 
 
-SCENARIO("std::string trim functions") {
+SCENARIO("std::string trim functions", "[libstd][string_view]") {
     const char *str = "   trim me";
     string_view v = str;
     REQUIRE(v.compare("   trim me") == 0);

--- a/test/libstd/tuple.cpp
+++ b/test/libstd/tuple.cpp
@@ -70,7 +70,7 @@ public:
 
 };
 
-SCENARIO("std::integer_sequence") {
+SCENARIO("std::integer_sequence", "[libstd][tuple]") {
     using seq5 = make_integer_sequence<int, 5>;
     using seq10 = make_index_sequence<10>;
     using seq18 = make_integer_sequence<char, 18>;
@@ -92,9 +92,8 @@ SCENARIO("std::integer_sequence") {
     REQUIRE(s.output == "42315012345678910110123456789101112");
 }
 
-SCENARIO("std::tuple") {
+SCENARIO("std::tuple", "[libstd][tuple]") {
     GIVEN("0 class instances") {
 
     }
 }
-

--- a/test/libstd/type_traits.cpp
+++ b/test/libstd/type_traits.cpp
@@ -39,7 +39,7 @@
 
 using namespace ETLSTD;
 
-SCENARIO("std::signed, std_unsigned") {
+SCENARIO("std::signed, std_unsigned", "[libstd][type_traits]") {
     auto s1 = is_signed<uint8_t>::value;    REQUIRE(s1 == false);
     auto s2 = is_signed<char>::value;       REQUIRE(s2 == true);
     auto s3 = is_signed<int32_t>::value;    REQUIRE(s3 == true);
@@ -63,7 +63,7 @@ SCENARIO("std::signed, std_unsigned") {
     REQUIRE(is_unsigned_v<int64_t> == false);
 }
 
-SCENARIO("std::common_type, std::same_type") {
+SCENARIO("std::common_type, std::same_type", "[libstd][type_traits]") {
     class Base {};
     class Incarnation1 : Base {};
     class Incarnation2 : Base {};
@@ -75,7 +75,7 @@ SCENARIO("std::common_type, std::same_type") {
 }
 
 
-SCENARIO("std::make_signed, std::make_unsigned") {
+SCENARIO("std::make_signed, std::make_unsigned", "[libstd][type_traits]") {
     auto comp = is_same_v<make_signed_t<uint16_t>, int16_t>;
     REQUIRE(comp == true);
 
@@ -88,7 +88,7 @@ SCENARIO("std::make_signed, std::make_unsigned") {
 
 
 
-SCENARIO("Primary types _v") {
+SCENARIO("Primary types _v", "[libstd][type_traits]") {
     REQUIRE(is_void_v<void>);
     REQUIRE(!is_void_v<double>);
 
@@ -152,4 +152,3 @@ SCENARIO("Primary types _v") {
     REQUIRE(is_member_object_pointer<decltype(memberPointer)>::value);
 
 }
-

--- a/test/libstd/vector.cpp
+++ b/test/libstd/vector.cpp
@@ -38,8 +38,7 @@
 #include <libstd/include/vector>
 
 
-SCENARIO("vector") {
+SCENARIO("vector", "[libstd][vector]") {
     ETLSTD::vector<char> vec1;
     //REQUIRE(vec1.size() == 0);
 }
-


### PR DESCRIPTION
Tags existing libstd `SCENARIO`s with Catch tags (`[libstd][<header>]`) and
registers a `TestsETL-libstd` ctest target running just the libstd-tagged
subset, so libstd can be validated independently of the rest of the suite.

Adds `examples/avr/libstd_smoke.cpp`, exercising `array`/`chrono`/`queue`/
`string_view` under real AVR compilation, and generalizes the AVR smoke
CMake logic into a reusable `etl_add_avr_smoke_target()` function shared by
the existing `etl_avr_smoke` and the new `etl_avr_libstd_smoke` targets.
Both targets and the `ETL_BUILD_AVR_SMOKE` / `ETL_BUILD_HOST_TESTS` options
were reviewed by hand since `avr-g++` isn't available in this environment
(CI's `avr-smoke` job exercises the real compile).

Also drops the CI workflow's separate "Run libstd-focused tests" step: it
duplicated the new `TestsETL-libstd` ctest target already covered by the
preceding `ctest --test-dir build` invocation in the same job.

Rebased onto current master (past PR #100, which fixed unrelated AVR
register-naming build failures this branch's CI was blocked on).

Fixes #90