### PR TITLE
libstd: define an embedded string subset

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ ETL now targets a single **C++23** baseline across the repository:
 - AVR smoke builds target **modern-avr GCC 14.2+**
 - the default build system baseline is **CMake 3.25+**
 
-The bundled `libstd` directory remains a focused compatibility layer for the subset of standard-library facilities ETL uses on embedded targets; it is not a full reimplementation of the entire C++23 standard library.
+The bundled `libstd` directory remains a focused compatibility layer for the subset of standard-library facilities ETL uses on embedded targets; it is not a full reimplementation of the entire C++23 standard library. In particular, `<string>` now means a small owning string subset with `string_view` interop, append/resize/reserve support, and explicit non-goals around full hosted `std::string` parity.
 
 
 Host-side build and tests

--- a/libstd/include/h/char_traits.h
+++ b/libstd/include/h/char_traits.h
@@ -32,56 +32,68 @@
 //  POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <string.h>
+
 #include <etl/ioports.h>
 #include <libstd/include/algorithm>
 
 namespace ETLSTD {
 
-template<typename CharT>
-struct char_traits {
-    using char_type	  = CharT;
-    using int_type    = CharT;
+template <typename CharT> struct char_traits {
+    using char_type = CharT;
+    using int_type = CharT;
 
-    using off_type    = etl::Device::OffType;
-    using pos_type    = etl::Device::OffType;
+    using off_type = etl::Device::OffType;
+    using pos_type = etl::Device::OffType;
 
-    using state_type  = CharT;
+    using state_type = CharT;
 
-    static void assign(char_type& r, const char_type& a) noexcept                       { r = a; }
-    static char_type* assign(char_type* p, std::size_t count, char_type a)              { fill_n(p, count, a); return p; }    
-    static constexpr bool eq(const char_type& c1, const char_type& c2) noexcept         { return c1 == c2; }
-    static constexpr char_type to_char_type(const int_type& i) noexcept                 { return static_cast<char_type>(i); }
-    static constexpr int_type to_int_type(const char_type& c) noexcept                  { return static_cast<int_type>(c); }
-    static constexpr bool eq_int_type(const int_type& a, const int_type& b) noexcept    { return a == b; }
-    static constexpr bool lt(const char_type& c1, const char_type& c2) noexcept         { return c1 < c2; }		
+    static void assign(char_type &r, const char_type &a) noexcept { r = a; }
+    static char_type *assign(char_type *p, size_t count, char_type a) {
+        fill_n(p, count, a);
+        return p;
+    }
+    static constexpr bool eq(const char_type &c1, const char_type &c2) noexcept { return c1 == c2; }
+    static constexpr char_type to_char_type(const int_type &i) noexcept { return static_cast<char_type>(i); }
+    static constexpr int_type to_int_type(const char_type &c) noexcept { return static_cast<int_type>(c); }
+    static constexpr bool eq_int_type(const int_type &a, const int_type &b) noexcept { return a == b; }
+    static constexpr bool lt(const char_type &c1, const char_type &c2) noexcept { return c1 < c2; }
 
-    static char_type* move(char_type* s1, const char_type* s2, size_t n)                { memmove(s1, s2, n * sizeof(char_type)); return s1; }
-    static char_type* copy(char_type* s1, const char_type* s2, size_t n)                { memcpy(s1, s2, n * sizeof(char_type)); return s1; }
+    static char_type *move(char_type *s1, const char_type *s2, size_t n) {
+        memmove(s1, s2, n * sizeof(char_type));
+        return s1;
+    }
+    static char_type *copy(char_type *s1, const char_type *s2, size_t n) {
+        memcpy(s1, s2, n * sizeof(char_type));
+        return s1;
+    }
 
-    static int compare(const char_type* s1, const char_type* s2, size_t n) {
-        for (size_t i=0; i<n; ++i) {
-            if (!eq(s1[i], s2[i])) return s1[i]<s2[i] ? -1 : 1;
+    static int compare(const char_type *s1, const char_type *s2, size_t n) {
+        for (size_t i = 0; i < n; ++i) {
+            if (!eq(s1[i], s2[i]))
+                return s1[i] < s2[i] ? -1 : 1;
         }
         return 0;
     }
-  
-    static size_t length(const char_type* s) {
+
+    static size_t length(const char_type *s) {
         const char_type null_char = char_type();
         size_t nbChars = 0;
         for (; !eq(s[nbChars], null_char); ++nbChars) {}
-	    return nbChars;
+        return nbChars;
     }
 
-    static const char_type* find(const char_type* s, int n, const char_type& c) {
+    static const char_type *find(const char_type *s, int n, const char_type &c) {
         for (; n > 0; ++s, --n) {
-            if (eq(*s, c)) return s;
+            if (eq(*s, c))
+                return s;
         }
         return 0;
     }
-  
-    static char_type eos()                                          { return static_cast<int_type>(0); }
-    static constexpr int_type eof() noexcept                        { return static_cast<int_type>(-1); }
-    static constexpr int_type not_eof(const int_type &i) noexcept   { return !eq_int_type(i, eof()) ? i : 0; }
-};  
 
-}
+    static char_type eos() { return static_cast<int_type>(0); }
+    static constexpr int_type eof() noexcept { return static_cast<int_type>(-1); }
+    static constexpr int_type not_eof(const int_type &i) noexcept { return !eq_int_type(i, eof()) ? i : 0; }
+};
+
+} // namespace ETLSTD

--- a/libstd/include/string
+++ b/libstd/include/string
@@ -36,6 +36,7 @@
 
 #include <libstd/include/algorithm>
 #include <libstd/include/cstddef>
+#include <libstd/include/functional>
 #include <libstd/include/iterator>
 #include <libstd/include/memory>
 #include <libstd/include/string_view>
@@ -209,7 +210,8 @@ public:
 
     void assign(const value_type *s, size_type count) {
         difference_type sourceOffset = 0;
-        const bool overlaps = buffer_ != nullptr && s >= buffer_ && s < (buffer_ + capacity_ + 1);
+        constexpr ETLSTD::less<const value_type *> less{};
+        const bool overlaps = buffer_ != nullptr && !less(s, buffer_) && less(s, buffer_ + capacity_ + 1);
         if (overlaps)
             sourceOffset = s - buffer_;
 
@@ -246,7 +248,8 @@ public:
             return *this;
 
         difference_type sourceOffset = 0;
-        const bool overlaps = buffer_ != nullptr && s >= buffer_ && s < (buffer_ + capacity_ + 1);
+        constexpr ETLSTD::less<const value_type *> less{};
+        const bool overlaps = buffer_ != nullptr && !less(s, buffer_) && less(s, buffer_ + capacity_ + 1);
         if (overlaps)
             sourceOffset = s - buffer_;
 
@@ -254,7 +257,10 @@ public:
         if (overlaps)
             s = buffer_ + sourceOffset;
 
-        traits_type::copy(buffer_ + length_, s, count);
+        if (overlaps)
+            traits_type::move(buffer_ + length_, s, count);
+        else
+            traits_type::copy(buffer_ + length_, s, count);
         length_ += count;
         terminate();
         return *this;

--- a/libstd/include/string
+++ b/libstd/include/string
@@ -32,36 +32,374 @@
 //  POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-
 #include "h/char_traits.h"
-#include <libstd/include/vector>
-#include <libstd/include/memory>
+
+#include <libstd/include/algorithm>
+#include <libstd/include/cstddef>
 #include <libstd/include/iterator>
+#include <libstd/include/memory>
+#include <libstd/include/string_view>
+#include <libstd/include/utility>
 
 namespace ETLSTD {
 
-template<typename CharT, typename Traits = char_traits<CharT>, typename Allocator = allocator<CharT>>
-class basic_string {
+template <typename CharT, typename Traits = char_traits<CharT>, typename Allocator = allocator<CharT>> class basic_string {
 public:
     using traits_type = Traits;
     using value_type = typename Traits::char_type;
     using allocator_type = Allocator;
     using size_type = size_t;
     using difference_type = ptrdiff_t;
-    using reference = value_type&;
-    using const_reference = const value_type&;
+    using reference = value_type &;
+    using const_reference = const value_type &;
     using pointer = typename allocator_traits<Allocator>::pointer;
     using const_pointer = typename allocator_traits<Allocator>::const_pointer;
-    using iterator = vector<CharT, Allocator>;
-    using const_iterator = vector<CharT, Allocator>;
+    using iterator = pointer;
+    using const_iterator = const_pointer;
     using const_reverse_iterator = ETLSTD::reverse_iterator<const_iterator>;
     using reverse_iterator = ETLSTD::reverse_iterator<iterator>;
+    using view_type = basic_string_view<CharT, Traits>;
 
-    static const size_type npos = -1;
+    inline static const size_type npos = size_type(-1);
 
+    basic_string() noexcept(noexcept(allocator_type())) : allocator_(), length_(0), capacity_(0), buffer_(nullptr) {}
 
+    explicit basic_string(const allocator_type &alloc) noexcept
+        : allocator_(alloc), length_(0), capacity_(0), buffer_(nullptr) {}
 
+    basic_string(size_type count, value_type ch, const allocator_type &alloc = allocator_type()) : basic_string(alloc) {
+        assign(count, ch);
+    }
+
+    basic_string(const value_type *s, const allocator_type &alloc = allocator_type()) : basic_string(alloc) { assign(s); }
+
+    basic_string(const value_type *s, size_type count, const allocator_type &alloc = allocator_type()) : basic_string(alloc) {
+        assign(s, count);
+    }
+
+    basic_string(view_type view, const allocator_type &alloc = allocator_type()) : basic_string(alloc) { assign(view); }
+
+    basic_string(const basic_string &other) : basic_string(other.allocator_) { assign(other.data(), other.size()); }
+
+    basic_string(basic_string &&other) noexcept
+        : allocator_(ETLSTD::move(other.allocator_)), length_(other.length_), capacity_(other.capacity_),
+          buffer_(other.buffer_) {
+        other.length_ = 0;
+        other.capacity_ = 0;
+        other.buffer_ = nullptr;
+    }
+
+    ~basic_string() { release(); }
+
+    basic_string &operator=(const basic_string &other) {
+        if (this != &other)
+            assign(other.data(), other.size());
+        return *this;
+    }
+
+    basic_string &operator=(basic_string &&other) noexcept {
+        if (this != &other) {
+            release();
+            allocator_ = ETLSTD::move(other.allocator_);
+            length_ = other.length_;
+            capacity_ = other.capacity_;
+            buffer_ = other.buffer_;
+            other.length_ = 0;
+            other.capacity_ = 0;
+            other.buffer_ = nullptr;
+        }
+        return *this;
+    }
+
+    basic_string &operator=(const value_type *s) {
+        assign(s);
+        return *this;
+    }
+
+    basic_string &operator=(view_type view) {
+        assign(view);
+        return *this;
+    }
+
+    iterator begin() noexcept { return mutable_data(); }
+
+    const_iterator begin() const noexcept { return data(); }
+
+    const_iterator cbegin() const noexcept { return data(); }
+
+    iterator end() noexcept { return mutable_data() + length_; }
+
+    const_iterator end() const noexcept { return data() + length_; }
+
+    const_iterator cend() const noexcept { return data() + length_; }
+
+    reverse_iterator rbegin() noexcept { return reverse_iterator(end()); }
+
+    const_reverse_iterator rbegin() const noexcept { return const_reverse_iterator(end()); }
+
+    const_reverse_iterator crbegin() const noexcept { return const_reverse_iterator(cend()); }
+
+    reverse_iterator rend() noexcept { return reverse_iterator(begin()); }
+
+    const_reverse_iterator rend() const noexcept { return const_reverse_iterator(begin()); }
+
+    const_reverse_iterator crend() const noexcept { return const_reverse_iterator(cbegin()); }
+
+    reference operator[](size_type pos) { return mutable_data()[pos]; }
+
+    const_reference operator[](size_type pos) const { return data()[pos]; }
+
+    reference front() { return mutable_data()[0]; }
+
+    const_reference front() const { return data()[0]; }
+
+    reference back() { return mutable_data()[length_ - 1]; }
+
+    const_reference back() const { return data()[length_ - 1]; }
+
+    [[nodiscard]] bool empty() const noexcept { return length_ == 0; }
+
+    size_type size() const noexcept { return length_; }
+
+    size_type length() const noexcept { return length_; }
+
+    size_type capacity() const noexcept { return capacity_; }
+
+    size_type max_size() const noexcept { return (npos / sizeof(value_type)) - 1; }
+
+    const_pointer data() const noexcept { return buffer_ ? buffer_ : empty_data(); }
+
+    pointer data() noexcept { return mutable_data(); }
+
+    const_pointer c_str() const noexcept { return data(); }
+
+    void clear() noexcept {
+        length_ = 0;
+        if (buffer_)
+            buffer_[0] = null_terminator();
+    }
+
+    void reserve(size_type newCapacity) {
+        if (newCapacity <= capacity_)
+            return;
+        reallocate(newCapacity);
+    }
+
+    void resize(size_type count) { resize(count, value_type()); }
+
+    void resize(size_type count, value_type ch) {
+        if (count <= length_) {
+            length_ = count;
+            terminate();
+            return;
+        }
+
+        ensure_capacity(count);
+        traits_type::assign(buffer_ + length_, count - length_, ch);
+        length_ = count;
+        terminate();
+    }
+
+    void assign(size_type count, value_type ch) {
+        clear();
+        resize(count, ch);
+    }
+
+    void assign(const value_type *s) { assign(s, traits_type::length(s)); }
+
+    void assign(const value_type *s, size_type count) {
+        difference_type sourceOffset = 0;
+        const bool overlaps = buffer_ != nullptr && s >= buffer_ && s < (buffer_ + capacity_ + 1);
+        if (overlaps)
+            sourceOffset = s - buffer_;
+
+        ensure_capacity(count);
+        if (count != 0) {
+            if (overlaps)
+                s = buffer_ + sourceOffset;
+            if (overlaps)
+                traits_type::move(buffer_, s, count);
+            else
+                traits_type::copy(buffer_, s, count);
+        }
+        length_ = count;
+        terminate();
+    }
+
+    void assign(view_type view) { assign(view.data(), view.size()); }
+
+    basic_string &append(size_type count, value_type ch) {
+        if (count == 0)
+            return *this;
+
+        ensure_capacity(length_ + count);
+        traits_type::assign(buffer_ + length_, count, ch);
+        length_ += count;
+        terminate();
+        return *this;
+    }
+
+    basic_string &append(const value_type *s) { return append(s, traits_type::length(s)); }
+
+    basic_string &append(const value_type *s, size_type count) {
+        if (count == 0)
+            return *this;
+
+        difference_type sourceOffset = 0;
+        const bool overlaps = buffer_ != nullptr && s >= buffer_ && s < (buffer_ + capacity_ + 1);
+        if (overlaps)
+            sourceOffset = s - buffer_;
+
+        ensure_capacity(length_ + count);
+        if (overlaps)
+            s = buffer_ + sourceOffset;
+
+        traits_type::copy(buffer_ + length_, s, count);
+        length_ += count;
+        terminate();
+        return *this;
+    }
+
+    basic_string &append(view_type view) { return append(view.data(), view.size()); }
+
+    basic_string &push_back(value_type ch) { return append(1, ch); }
+
+    basic_string &operator+=(value_type ch) { return append(1, ch); }
+
+    basic_string &operator+=(const value_type *s) { return append(s); }
+
+    basic_string &operator+=(view_type view) { return append(view); }
+
+    size_type copy(value_type *dest, size_type count, size_type pos = 0) const {
+        if (pos >= length_)
+            return 0;
+
+        const auto copied = count < (length_ - pos) ? count : (length_ - pos);
+        traits_type::copy(dest, data() + pos, copied);
+        return copied;
+    }
+
+    int compare(view_type view) const noexcept { return this->view().compare(view); }
+
+    int compare(const value_type *s) const { return compare(view_type(s)); }
+
+    bool starts_with(view_type prefix) const noexcept { return view().starts_with(prefix); }
+
+    bool starts_with(value_type ch) const noexcept { return !empty() && traits_type::eq(front(), ch); }
+
+    bool starts_with(const value_type *s) const { return starts_with(view_type(s)); }
+
+    basic_string substr(size_type pos = 0, size_type count = npos) const {
+        if (pos >= length_)
+            return basic_string(allocator_);
+
+        const auto remaining = length_ - pos;
+        const auto copied = count < remaining ? count : remaining;
+        return basic_string(data() + pos, copied, allocator_);
+    }
+
+    view_type view() const noexcept { return view_type(data(), length_); }
+
+    operator view_type() const noexcept { return view(); }
+
+    void swap(basic_string &other) noexcept {
+        ETLSTD::swap(allocator_, other.allocator_);
+        ETLSTD::swap(length_, other.length_);
+        ETLSTD::swap(capacity_, other.capacity_);
+        ETLSTD::swap(buffer_, other.buffer_);
+    }
+
+private:
+    static value_type null_terminator() noexcept { return value_type(); }
+
+    static const_pointer empty_data() noexcept {
+        static const value_type empty[1] = {value_type()};
+        return empty;
+    }
+
+    pointer mutable_data() noexcept { return buffer_ ? buffer_ : const_cast<pointer>(empty_data()); }
+
+    void ensure_capacity(size_type required) {
+        if (required <= capacity_)
+            return;
+
+        size_type newCapacity = capacity_ == 0 ? required : capacity_;
+        while (newCapacity < required) {
+            const auto doubled = newCapacity * 2;
+            if (doubled <= newCapacity) {
+                newCapacity = required;
+                break;
+            }
+            newCapacity = doubled;
+        }
+        reallocate(newCapacity);
+    }
+
+    void reallocate(size_type newCapacity) {
+        auto *newBuffer = allocator_.allocate(newCapacity + 1);
+        // Copy the full old allocation, not just size(): a self-aliasing assign/append may read past length_.
+        if (buffer_)
+            traits_type::copy(newBuffer, buffer_, capacity_ + 1);
+        newBuffer[length_] = null_terminator();
+
+        if (buffer_)
+            allocator_.deallocate(buffer_, capacity_ + 1);
+
+        buffer_ = newBuffer;
+        capacity_ = newCapacity;
+    }
+
+    void terminate() noexcept {
+        if (buffer_)
+            buffer_[length_] = null_terminator();
+    }
+
+    void release() {
+        if (!buffer_)
+            return;
+
+        allocator_.deallocate(buffer_, capacity_ + 1);
+        buffer_ = nullptr;
+        length_ = 0;
+        capacity_ = 0;
+    }
+
+private:
+    allocator_type allocator_;
+    size_type length_;
+    size_type capacity_;
+    pointer buffer_;
 };
+
+template <typename CharT, typename Traits, typename Allocator>
+bool operator==(const basic_string<CharT, Traits, Allocator> &lhs, const basic_string<CharT, Traits, Allocator> &rhs) noexcept {
+    return lhs.compare(rhs.view()) == 0;
+}
+
+template <typename CharT, typename Traits, typename Allocator>
+bool operator==(const basic_string<CharT, Traits, Allocator> &lhs, basic_string_view<CharT, Traits> rhs) noexcept {
+    return lhs.compare(rhs) == 0;
+}
+
+template <typename CharT, typename Traits, typename Allocator>
+bool operator==(basic_string_view<CharT, Traits> lhs, const basic_string<CharT, Traits, Allocator> &rhs) noexcept {
+    return rhs == lhs;
+}
+
+template <typename CharT, typename Traits, typename Allocator>
+bool operator!=(const basic_string<CharT, Traits, Allocator> &lhs, const basic_string<CharT, Traits, Allocator> &rhs) noexcept {
+    return !(lhs == rhs);
+}
+
+template <typename CharT, typename Traits, typename Allocator>
+bool operator!=(const basic_string<CharT, Traits, Allocator> &lhs, basic_string_view<CharT, Traits> rhs) noexcept {
+    return !(lhs == rhs);
+}
+
+template <typename CharT, typename Traits, typename Allocator>
+bool operator!=(basic_string_view<CharT, Traits> lhs, const basic_string<CharT, Traits, Allocator> &rhs) noexcept {
+    return !(lhs == rhs);
+}
 
 using string = basic_string<char>;
 

--- a/libstd/readme.md
+++ b/libstd/readme.md
@@ -22,3 +22,20 @@ This bundled library is intentionally partial. It primarily covers the following
 - `<utility>`
 - `<array>`
 - `<exception>`
+- `<string_view>`
+- a deliberately small `<string>` subset for owning, NUL-terminated dynamic text buffers
+
+`<string>` support is intentionally embedded-oriented rather than a promise of full `std::basic_string` coverage. The maintained subset currently includes:
+
+- construction from C strings, counted ranges, `string_view`, copies, and moves
+- contiguous mutable storage via `data()` / `c_str()`
+- iteration with pointer iterators
+- `size()`, `length()`, `empty()`, `capacity()`, `reserve()`, `resize()`, and `clear()`
+- `append(...)`, `push_back(...)`, `operator+=`, `copy(...)`, `compare(...)`, `substr(...)`, and `starts_with(...)`
+- cheap interop with `string_view`
+
+The following are intentionally **not** part of the promised surface today:
+
+- small-string optimization or copy-on-write
+- the full search / replace / insert / erase family from hosted `std::basic_string`
+- allocator-heavy API parity work beyond ETL's current embedded needs

--- a/test/libstd/string.cpp
+++ b/test/libstd/string.cpp
@@ -107,6 +107,21 @@ SCENARIO("std::string subset handles self-assign when count exceeds capacity", "
     REQUIRE(tail[3] == '\0');
 }
 
+SCENARIO("std::string subset handles self-append overlap without corrupting data", "[libstd][string]") {
+    string text("ABCDEFGH");
+    text.reserve(13);
+    REQUIRE(text.capacity() >= 13);
+
+    text.append(text.data() + 4, 5);
+
+    REQUIRE(text.size() == 13);
+    REQUIRE(text[8] == 'E');
+    REQUIRE(text[9] == 'F');
+    REQUIRE(text[10] == 'G');
+    REQUIRE(text[11] == 'H');
+    REQUIRE(text[12] == '\0');
+}
+
 SCENARIO("std::string subset interoperates with string_view and move semantics", "[libstd][string]") {
     string source("embedded");
     string copy(source);

--- a/test/libstd/string.cpp
+++ b/test/libstd/string.cpp
@@ -30,21 +30,99 @@
 //  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 //  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 //  POSSIBILITY OF SUCH DAMAGE.
-#//include <catch.hpp>
+#include <catch.hpp>
+
 #define __Mock_Mock__
 #define ETLSTD etlstd
 #include <libstd/include/string>
+
 using namespace ETLSTD;
 
+SCENARIO("std::string subset owns null-terminated storage", "[libstd][string]") {
+    string text("ETL");
 
-  /*
-SCENARIO("char_traits") {
-
-    REQUIRE(char_traits<char>::length("Test string") == 11);
+    REQUIRE(text.size() == 3);
+    REQUIRE(text.length() == 3);
+    REQUIRE_FALSE(text.empty());
+    REQUIRE(text.front() == 'E');
+    REQUIRE(text.back() == 'L');
+    REQUIRE(text[1] == 'T');
+    REQUIRE(text.c_str()[3] == '\0');
+    REQUIRE(text.view() == "ETL"sv);
 }
-*/
 
-static auto func() {
-    return char_traits<char>::length("Test string");
+SCENARIO("std::string subset supports embedded-friendly growth", "[libstd][string]") {
+    string text("ET");
+
+    text.reserve(8);
+    REQUIRE(text.capacity() >= 8);
+    REQUIRE(text.view() == "ET"sv);
+
+    text += 'L';
+    text.append(" std");
+    text.push_back('!');
+    REQUIRE(text.view() == "ETL std!"sv);
+
+    text.append(text.data(), 3);
+    REQUIRE(text.view() == "ETL std!ETL"sv);
+
+    text.resize(3);
+    REQUIRE(text.view() == "ETL"sv);
+    REQUIRE(text.c_str()[3] == '\0');
+
+    text.resize(5, '?');
+    REQUIRE(text.view() == "ETL??"sv);
+
+    text.clear();
+    REQUIRE(text.empty());
+    REQUIRE(text.size() == 0);
+    REQUIRE(text.c_str()[0] == '\0');
 }
 
+SCENARIO("std::string subset handles self-assign when count exceeds capacity", "[libstd][string]") {
+    string text("AB");
+    text.append("CD");
+    text.resize(2);
+    REQUIRE(text.capacity() == 4);
+
+    text.assign(text.data(), 5);
+    REQUIRE(text.size() == 5);
+    REQUIRE(text[0] == 'A');
+    REQUIRE(text[1] == 'B');
+    REQUIRE(text[2] == '\0');
+    REQUIRE(text[3] == 'D');
+    REQUIRE(text[4] == '\0');
+
+    string tail("hi");
+    tail.reserve(6);
+    tail.resize(6, 'Z');
+    tail.resize(2);
+    REQUIRE(tail.capacity() == 6);
+
+    tail.assign(tail.data() + 3, 7);
+    REQUIRE(tail.size() == 7);
+    REQUIRE(tail[0] == 'Z');
+    REQUIRE(tail[1] == 'Z');
+    REQUIRE(tail[2] == 'Z');
+    REQUIRE(tail[3] == '\0');
+}
+
+SCENARIO("std::string subset interoperates with string_view and move semantics", "[libstd][string]") {
+    string source("embedded");
+    string copy(source);
+    string_view prefix("embed");
+
+    REQUIRE(copy == source);
+    REQUIRE(copy.starts_with(prefix));
+
+    char buffer[5] = {};
+    REQUIRE(copy.copy(buffer, 4) == 4);
+    REQUIRE(string_view(buffer, 4) == "embe"sv);
+
+    string tail = copy.substr(3, 5);
+    REQUIRE(tail.view() == "edded"sv);
+
+    string moved(ETLSTD::move(copy));
+    REQUIRE(moved.view() == "embedded"sv);
+    REQUIRE(copy.empty());
+}


### PR DESCRIPTION
## Summary

Replaces the placeholder `basic_string` (whose `iterator` aliased `vector<CharT,Allocator>`) with a real owning, NUL-terminated `<string>` subset: construction from C strings/counted ranges/`string_view`, `assign`/`append`/`push_back`/`operator+=`, `resize`/`reserve`/`clear`, `copy`/`compare`/`substr`/`starts_with`, move semantics, and `string_view` interop/comparison operators.

Ported from the `issue-92-string` branch onto current master (which now has the AVR ioports register-naming fix from PR #100), then given a quality pass:

- **Fixed a use-after-free** in `assign()`/`append()`: the self-overlap check only compared the source pointer against `size()` rather than `capacity()`. A source pointer past the current length but still inside the buffer's allocation was misclassified as non-overlapping; if that call also forced growth, the (uninitialized-detection-passed) source read landed on the just-freed old buffer. Overlap detection now spans the full allocation, and `reallocate()` preserves the whole old buffer (not just `length_` bytes) so aliased reads stay consistent across a resize. Verified with a standalone ASan/UBSan repro before and after the fix, and added a regression test (`std::string subset handles self-assign when count exceeds capacity`) covering both the reallocate-preserve path and the widened overlap bound.
- Replaced a stray `std::size_t` in `char_traits.h` with the unqualified `size_t` used everywhere else in the file.
- Ran `clang-format` over all touched files per the repo's `.clang-format`.
- `char_traits.h` now includes `<string.h>` explicitly for `memcpy`/`memmove` instead of relying on a transitive include.

## Test plan

- [x] `cmake -S . -B build && cmake --build build -j$(nproc)`
- [x] `ctest --test-dir build --output-on-failure` (all tests pass)
- [x] Standalone ASan/UBSan build of the full test suite — no errors
- [x] Standalone repro of the use-after-free against the pre-fix code, confirmed fixed post-fix

Fixes #92