### PR TITLE
Fix shared_ptr double-free on copy assignment

### DIFF
--- a/libstd/include/memory
+++ b/libstd/include/memory
@@ -41,114 +41,115 @@
 namespace ETLSTD {
 namespace etlHelper {
 // addressof helpers taken from Boost library
-template<typename T> struct addressof_ref {
-    T & v_;
-    addressof_ref(T & v) : v_(v) {}
-    operator T& () const { return v_; }
+template <typename T> struct addressof_ref {
+    T &v_;
+    addressof_ref(T &v) : v_(v) {}
+    operator T &() const { return v_; }
 
 private:
-    addressof_ref & operator=(const addressof_ref &);
+    addressof_ref &operator=(const addressof_ref &);
 };
 
-template<typename T> struct addressof_impl {
-    static T * f(T & v, long) {
-        return reinterpret_cast<T*>(&const_cast<char&>(reinterpret_cast<const volatile char &>(v)));
-    }
-    static T * f(T * v, int) { return v; }
+template <typename T> struct addressof_impl {
+    static T *f(T &v, long) { return reinterpret_cast<T *>(&const_cast<char &>(reinterpret_cast<const volatile char &>(v))); }
+    static T *f(T *v, int) { return v; }
 };
-} //namespace etlHelper
+} // namespace etlHelper
 
-template<typename T>
-class allocator {
+template <typename T> class allocator {
 public:
     using value_type = T;
     using propagate_on_container_move_assignment = true_type;
     using is_always_equal = true_type;
 
 public:
-    template<typename U> struct rebind { using other = allocator<U>; };
+    template <typename U> struct rebind {
+        using other = allocator<U>;
+    };
 
     allocator() noexcept {}
-    allocator(const allocator&) noexcept {};
-    template<typename T2> allocator(const allocator<T2>&) noexcept {};
+    allocator(const allocator &) noexcept {};
+    template <typename T2> allocator(const allocator<T2> &) noexcept {};
     ~allocator() {};
 
-    T* allocate(size_t n) { return reinterpret_cast<T*>(::operator new(n * sizeof(T))); }
-    void deallocate(T* p, size_t) { ::operator delete(p); }
-    bool operator==(allocator const&) { return true; }
-    bool operator!=(allocator const& a) { return !operator==(a); }
+    T *allocate(size_t n) { return reinterpret_cast<T *>(::operator new(n * sizeof(T))); }
+    void deallocate(T *p, size_t) { ::operator delete(p); }
+    bool operator==(allocator const &) { return true; }
+    bool operator!=(allocator const &a) { return !operator==(a); }
 };
 
 namespace etlHelper {
-template<typename T> using hasDiffT = decltype(T::difference_type);
-template<typename T> using hasRebind = typename T::template rebind<T>;
-template<typename T> using hasPointer = decltype(T::pointer);
-template<typename T> using hasConstPointer = decltype(T::const_pointer);
-template<typename T> using hasDifferenceType = decltype(T::difference_type);
-template<typename T> using hasSizeType = decltype(T::size_type);
-template<typename T> using hasVoidPointer = decltype(T::void_pointer);
-template<typename T> using hasConstVoidPointer = decltype(T::const_void_pointer);
-template<typename T> using hasPropagateCopy = decltype(T::propagate_on_container_copy_assignment);
-template<typename T> using hasPropagateMove = decltype(T::propagate_on_container_move_assignment);
-template<typename T> using hasPropagateSwap = decltype(T::propagate_on_container_swap);
-template<typename T> using hasIsAlwaysEqual = decltype(T::is_always_equal);
-template<typename T> using hasConstruct = decltype(T::construct);
+template <typename T> using hasDiffT = decltype(T::difference_type);
+template <typename T> using hasRebind = typename T::template rebind<T>;
+template <typename T> using hasPointer = decltype(T::pointer);
+template <typename T> using hasConstPointer = decltype(T::const_pointer);
+template <typename T> using hasDifferenceType = decltype(T::difference_type);
+template <typename T> using hasSizeType = decltype(T::size_type);
+template <typename T> using hasVoidPointer = decltype(T::void_pointer);
+template <typename T> using hasConstVoidPointer = decltype(T::const_void_pointer);
+template <typename T> using hasPropagateCopy = decltype(T::propagate_on_container_copy_assignment);
+template <typename T> using hasPropagateMove = decltype(T::propagate_on_container_move_assignment);
+template <typename T> using hasPropagateSwap = decltype(T::propagate_on_container_swap);
+template <typename T> using hasIsAlwaysEqual = decltype(T::is_always_equal);
+template <typename T> using hasConstruct = decltype(T::construct);
 } // namespace etlHelper
 
-template<typename Ptr>
-struct pointer_traits {
+template <typename Ptr> struct pointer_traits {
     using pointer = Ptr;
     using element_type = typename Ptr::element_type;
     using difference_type = detected_or_t<ptrdiff_t, etlHelper::hasDiffT, Ptr>;
-    template<typename U> using rebind = detected_or_t<U*, etlHelper::hasRebind, U>;
+    template <typename U> using rebind = detected_or_t<U *, etlHelper::hasRebind, U>;
 };
 
-template<typename T>
-struct pointer_traits<T*> {
-    using pointer = T*;
+template <typename T> struct pointer_traits<T *> {
+    using pointer = T *;
     using element_type = T;
     using difference_type = ptrdiff_t;
-    template <typename U> using rebind = U*;
+    template <typename U> using rebind = U *;
 };
 
-
-template<typename Alloc>
-struct allocator_traits {
+template <typename Alloc> struct allocator_traits {
     using value_type = typename Alloc::value_type;
     using allocator_type = Alloc;
-    //using pointer = detected_or_t<value_type*, etlHelper::hasPointer, allocator_type>;
-    using pointer = value_type*;
-    using const_pointer = detected_or_t<typename pointer_traits<pointer>::template rebind<const value_type>, etlHelper::hasConstPointer, allocator_type>;
-    using void_pointer = detected_or_t<typename pointer_traits<pointer>::template rebind<void>, etlHelper::hasVoidPointer, allocator_type>;
-    using const_void_pointer = detected_or_t<typename pointer_traits<pointer>::template rebind<const void>, etlHelper::hasConstVoidPointer, allocator_type>;
-    using difference_type = detected_or_t<typename pointer_traits<pointer>::difference_type, etlHelper::hasDifferenceType, allocator_type>;
-    using size_type = detected_or_t < make_unsigned_t<difference_type>, etlHelper::hasSizeType, allocator_type>;
+    // using pointer = detected_or_t<value_type*, etlHelper::hasPointer, allocator_type>;
+    using pointer = value_type *;
+    using const_pointer = detected_or_t<typename pointer_traits<pointer>::template rebind<const value_type>,
+                                        etlHelper::hasConstPointer, allocator_type>;
+    using void_pointer =
+        detected_or_t<typename pointer_traits<pointer>::template rebind<void>, etlHelper::hasVoidPointer, allocator_type>;
+    using const_void_pointer = detected_or_t<typename pointer_traits<pointer>::template rebind<const void>,
+                                             etlHelper::hasConstVoidPointer, allocator_type>;
+    using difference_type =
+        detected_or_t<typename pointer_traits<pointer>::difference_type, etlHelper::hasDifferenceType, allocator_type>;
+    using size_type = detected_or_t<make_unsigned_t<difference_type>, etlHelper::hasSizeType, allocator_type>;
     using propagate_on_container_copy_assignment = detected_or_t<false_type, etlHelper::hasPropagateCopy, allocator_type>;
     using propagate_on_container_move_assignment = detected_or_t<false_type, etlHelper::hasPropagateMove, allocator_type>;
     using propagate_on_container_swap = detected_or_t<false_type, etlHelper::hasPropagateSwap, allocator_type>;
     using is_always_equal = detected_or_t<typename is_empty<allocator_type>::type, etlHelper::hasIsAlwaysEqual, allocator_type>;
 
-
-    template<typename T, typename... Args, typename DummyInt = uint8_t, enable_if_t<!is_detected_v<etlHelper::hasConstruct, allocator_type>, DummyInt> = 0>
-    static void construct(Alloc& a, T* p, Args&&... args) {
-        ::new (static_cast<void*>(p)) T(std::forward<Args>(args)...);
+    template <typename T, typename... Args, typename DummyInt = uint8_t,
+              enable_if_t<!is_detected_v<etlHelper::hasConstruct, allocator_type>, DummyInt> = 0>
+    static void construct(Alloc &a, T *p, Args &&...args) {
+        ::new (static_cast<void *>(p)) T(forward<Args>(args)...);
     }
 
-    template<typename T, typename... Args, typename DummyInt = uint8_t, enable_if_t<is_detected_v<etlHelper::hasConstruct, allocator_type>, DummyInt> = 0>
-    static void construct(Alloc& a, T* p, Args&&... args) {
+    template <typename T, typename... Args, typename DummyInt = uint8_t,
+              enable_if_t<is_detected_v<etlHelper::hasConstruct, allocator_type>, DummyInt> = 0>
+    static void construct(Alloc &a, T *p, Args &&...args) {
         allocator_type::construct(p, forward<Args>(args)...);
     }
 };
 
-template<typename T> constexpr T* addressof(T& arg) {
+template <typename T> constexpr T *addressof(T &arg) {
     return etlHelper::addressof_impl<T>::f(etlHelper::addressof_ref<T>(arg), 0);
 }
 
 namespace etlHelper {
 class refCounter {
     long count;
+
 public:
-    refCounter() : count(1) { }
+    refCounter() : count(1) {}
     virtual ~refCounter() = default;
 
     void inc() { ++count; }
@@ -156,54 +157,72 @@ public:
     long use_count() const { return count; }
 };
 
-template<typename T> struct refCountAndPointer : refCounter {
-    T* pointee;
-    explicit refCountAndPointer(T* p) : pointee(p) { }
+template <typename T> struct refCountAndPointer : refCounter {
+    T *pointee;
+    explicit refCountAndPointer(T *p) : pointee(p) {}
     ~refCountAndPointer() override { delete pointee; }
 };
 
-template<typename T> struct refCountAndObject : refCounter {
+template <typename T> struct refCountAndObject : refCounter {
     T object;
-    template<typename ... Args> refCountAndObject(Args && ...args) : object(args...) { }
+    template <typename... Args> refCountAndObject(Args &&...args) : object(args...) {}
 };
-} //namespace etlHelper
+} // namespace etlHelper
 
-template<typename T>
-class shared_ptr {
+template <typename T> class shared_ptr {
 public:
     using element_type = remove_extent_t<T>;
 
     constexpr shared_ptr() : pointee(nullptr), counter(nullptr) {}
-    constexpr shared_ptr(std::nullptr_t) : pointee(nullptr), counter(nullptr) {}
-    explicit shared_ptr(T* p) { createCounter(p); }
-    template <typename U> shared_ptr(const shared_ptr<U>& ptr) { *this = ptr; }
-    shared_ptr(const shared_ptr& ptr) : counter(ptr.counter), pointee(ptr.pointee) { if (use_count() > 0) counter->inc(); }
-    ~shared_ptr()       { release(); }
+    constexpr shared_ptr(nullptr_t) : pointee(nullptr), counter(nullptr) {}
+    explicit shared_ptr(T *p) : pointee(nullptr), counter(nullptr) { createCounter(p); }
+    template <typename U> shared_ptr(const shared_ptr<U> &ptr) : counter(ptr.counter), pointee(ptr.pointee) {
+        if (counter)
+            counter->inc();
+    }
+    shared_ptr(const shared_ptr &ptr) : counter(ptr.counter), pointee(ptr.pointee) {
+        if (counter)
+            counter->inc();
+    }
 
-    void reset()        { release(); }
-    void reset(T* p)    { release(); createCounter(p); }
+    // Aliasing constructor: shares ownership with ptr but points at p (e.g. a sub-object of *ptr).
+    template <typename U> shared_ptr(const shared_ptr<U> &ptr, T *p) : pointee(p), counter(ptr.counter) {
+        if (counter)
+            counter->inc();
+    }
 
-    shared_ptr& operator=(const shared_ptr& rhs) { 
+    ~shared_ptr() { release(); }
+
+    void reset() { release(); }
+    void reset(T *p) {
         release();
-        pointee = rhs.pointee;
-        counter = rhs.counter;
+        createCounter(p);
+    }
+
+    shared_ptr &operator=(const shared_ptr &rhs) {
+        shared_ptr(rhs).swap(*this);
         return *this;
     }
 
-    void swap(shared_ptr& lhs) {
-        std::swap(pointee, lhs.pointee);
-        std::swap(counter, lhs.counter);
+    void swap(shared_ptr &lhs) {
+        ETLSTD::swap(pointee, lhs.pointee);
+        ETLSTD::swap(counter, lhs.counter);
     }
 
-    operator bool()     const { return pointee != nullptr; }
-    bool unique()       const { return 1 == use_count(); }
-    long use_count()    const { return counter ? counter->use_count() : 0; }
-    T& operator*()      const { return *pointee; }
-    T* operator->()     const { return pointee; }
-    T* get(void)        const { return pointee; }
+    operator bool() const { return pointee != nullptr; }
+    bool unique() const { return 1 == use_count(); }
+    long use_count() const { return counter ? counter->use_count() : 0; }
+    T &operator*() const { return *pointee; }
+    T *operator->() const { return pointee; }
+    T *get(void) const { return pointee; }
 
 private:
-    void createCounter(T* p) {
+    void createCounter(T *p) {
+        if (p == nullptr) {
+            pointee = nullptr;
+            counter = nullptr;
+            return;
+        }
         auto tmp = new etlHelper::refCountAndPointer<T>(p);
         pointee = tmp->pointee;
         counter = tmp;
@@ -221,24 +240,31 @@ private:
     }
 
 private:
-    template<typename U> friend class shared_ptr;
-    template<typename T1, typename... Args> friend shared_ptr<T1> make_shared(Args&&... args);
-    T*                      pointee;
-    etlHelper::refCounter*  counter;
+    template <typename U> friend class shared_ptr;
+    template <typename T1, typename... Args> friend shared_ptr<T1> make_shared(Args &&...args);
+    T *pointee;
+    etlHelper::refCounter *counter;
 };
 
-
-template<typename T, typename U> bool operator==(const shared_ptr<T>& l, const shared_ptr<U>& r) { return (l.get() == r.get()); }
-template<typename T, typename U> bool operator!=(const shared_ptr<T>& l, const shared_ptr<U>& r) { return (l.get() != r.get()); }
-template<typename T, typename U> bool operator<=(const shared_ptr<T>& l, const shared_ptr<U>& r) { return (l.get() <= r.get()); }
-template<typename T, typename U> bool operator<(const shared_ptr<T>& l, const shared_ptr<U>& r) { return (l.get() < r.get()); }
-template<typename T, typename U> bool operator>=(const shared_ptr<T>& l, const shared_ptr<U>& r) { return (l.get() >= r.get()); }
-template<typename T, typename U> bool operator>(const shared_ptr<T>& l, const shared_ptr<U>& r) { return (l.get() > r.get()); }
-template<typename T, typename U>shared_ptr<T> static_pointer_cast(const shared_ptr<U>& ptr) {
-    return shared_ptr<T>(ptr, static_cast<typename shared_ptr<T>::element_type*>(ptr.get()));
+template <typename T, typename U> bool operator==(const shared_ptr<T> &l, const shared_ptr<U> &r) {
+    return (l.get() == r.get());
+}
+template <typename T, typename U> bool operator!=(const shared_ptr<T> &l, const shared_ptr<U> &r) {
+    return (l.get() != r.get());
+}
+template <typename T, typename U> bool operator<=(const shared_ptr<T> &l, const shared_ptr<U> &r) {
+    return (l.get() <= r.get());
+}
+template <typename T, typename U> bool operator<(const shared_ptr<T> &l, const shared_ptr<U> &r) { return (l.get() < r.get()); }
+template <typename T, typename U> bool operator>=(const shared_ptr<T> &l, const shared_ptr<U> &r) {
+    return (l.get() >= r.get());
+}
+template <typename T, typename U> bool operator>(const shared_ptr<T> &l, const shared_ptr<U> &r) { return (l.get() > r.get()); }
+template <typename T, typename U> shared_ptr<T> static_pointer_cast(const shared_ptr<U> &ptr) {
+    return shared_ptr<T>(ptr, static_cast<typename shared_ptr<T>::element_type *>(ptr.get()));
 }
 
-template<typename T, typename ... Args> shared_ptr<T> make_shared(Args && ... args) {
+template <typename T, typename... Args> shared_ptr<T> make_shared(Args &&...args) {
     shared_ptr<T> ptr;
     auto tmp = new etlHelper::refCountAndObject<T>(args...);
     ptr.pointee = &tmp->object;

--- a/libstd/include/memory
+++ b/libstd/include/memory
@@ -165,7 +165,7 @@ template <typename T> struct refCountAndPointer : refCounter {
 
 template <typename T> struct refCountAndObject : refCounter {
     T object;
-    template <typename... Args> refCountAndObject(Args &&...args) : object(args...) {}
+    template <typename... Args> refCountAndObject(Args &&...args) : object(forward<Args>(args)...) {}
 };
 } // namespace etlHelper
 
@@ -266,7 +266,7 @@ template <typename T, typename U> shared_ptr<T> static_pointer_cast(const shared
 
 template <typename T, typename... Args> shared_ptr<T> make_shared(Args &&...args) {
     shared_ptr<T> ptr;
-    auto tmp = new etlHelper::refCountAndObject<T>(args...);
+    auto tmp = new etlHelper::refCountAndObject<T>(forward<Args>(args)...);
     ptr.pointee = &tmp->object;
     ptr.counter = tmp;
 

--- a/test/libstd/memory.cpp
+++ b/test/libstd/memory.cpp
@@ -40,20 +40,17 @@
 
 class MyClass {
 public:
-    MyClass(uint32_t id) : id(id) {
-        instances++;
-    }
+    MyClass(uint32_t id) : id(id) { instances++; }
 
-    ~MyClass() {
-        instances--;
-    }
+    ~MyClass() { instances--; }
+
 public:
     static uint8_t instances;
     uint32_t id;
 };
 
 uint8_t MyClass::instances = 0;
-//using namespace etlTest::std;
+// using namespace etlTest::std;
 
 SCENARIO("std::unique_ptr") {
     GIVEN("0 class instances") {
@@ -90,17 +87,166 @@ SCENARIO("std::shared_ptr") {
             auto obj2 = obj;
             auto obj3 = obj;
             THEN("3 references are counted")
-                REQUIRE(obj.use_count() == 3);
-            
+            REQUIRE(obj.use_count() == 3);
+
             obj = nullptr;
-            THEN("ref count is decreased") 
-                REQUIRE(obj2.use_count() == 2);
-            
+            THEN("ref count is decreased")
+            REQUIRE(obj2.use_count() == 2);
+
             obj3.reset();
             REQUIRE(!obj3);
             REQUIRE(obj2.unique());
         }
 
+        WHEN("ptr is copy-assigned") {
+            auto assignee = ETLSTD::make_shared<MyClass>(654321);
+            REQUIRE(MyClass::instances == 2);
+
+            assignee = obj;
+
+            THEN("the previous pointee is released and ownership is shared") {
+                REQUIRE(MyClass::instances == 1);
+                REQUIRE(assignee.get() == obj.get());
+                REQUIRE(assignee->id == obj->id);
+                REQUIRE(obj.use_count() == 2);
+                REQUIRE(assignee.use_count() == 2);
+            }
+
+            obj.reset();
+
+            THEN("the assigned pointer keeps the managed object alive") {
+                REQUIRE(!obj);
+                REQUIRE(assignee);
+                REQUIRE(assignee->id == 123456);
+                REQUIRE(assignee.use_count() == 1);
+                REQUIRE(MyClass::instances == 1);
+            }
+        }
+
+        WHEN("ptr is assigned to itself") {
+            obj = obj;
+
+            THEN("ownership stays unchanged") {
+                REQUIRE(obj);
+                REQUIRE(obj.unique());
+                REQUIRE(obj.use_count() == 1);
+                REQUIRE(MyClass::instances == 1);
+            }
+        }
+
+        WHEN("ptr is reset to nullptr") {
+            auto obj2 = obj;
+            REQUIRE(obj.use_count() == 2);
+
+            obj.reset(nullptr);
+
+            THEN("only that owner releases its reference") {
+                REQUIRE(!obj);
+                REQUIRE(obj.use_count() == 0);
+                REQUIRE(obj2);
+                REQUIRE(obj2.use_count() == 1);
+                REQUIRE(MyClass::instances == 1);
+            }
+
+            obj2.reset();
+
+            THEN("the last release destroys the object") {
+                REQUIRE(!obj2);
+                REQUIRE(obj2.use_count() == 0);
+                REQUIRE(MyClass::instances == 0);
+            }
+        }
+
+        WHEN("ptrs are swapped") {
+            auto obj2 = ETLSTD::make_shared<MyClass>(654321);
+            auto obj3 = obj;
+            REQUIRE(obj.use_count() == 2);
+            REQUIRE(obj2.use_count() == 1);
+
+            obj.swap(obj2);
+
+            THEN("ownership and counts follow the handles") {
+                REQUIRE(obj->id == 654321);
+                REQUIRE(obj.use_count() == 1);
+                REQUIRE(obj2->id == 123456);
+                REQUIRE(obj2.use_count() == 2);
+                REQUIRE(obj3.get() == obj2.get());
+                REQUIRE(MyClass::instances == 2);
+            }
+        }
+
+        WHEN("copies are created and destroyed across nested scopes") {
+            {
+                auto obj2 = obj;
+                REQUIRE(obj.use_count() == 2);
+
+                {
+                    auto obj3 = obj2;
+                    REQUIRE(obj.use_count() == 3);
+                    REQUIRE(obj3.use_count() == 3);
+                }
+
+                REQUIRE(obj.use_count() == 2);
+                obj2.reset();
+                REQUIRE(obj.use_count() == 1);
+            }
+
+            THEN("the managed object stays alive until the last owner releases it") {
+                REQUIRE(obj);
+                REQUIRE(obj.unique());
+                REQUIRE(obj.use_count() == 1);
+                REQUIRE(MyClass::instances == 1);
+            }
+        }
+    }
+
+    GIVEN("A shared_ptr constructed from a null raw pointer") {
+        MyClass::instances = 0;
+        ETLSTD::shared_ptr<MyClass> obj(static_cast<MyClass *>(nullptr));
+
+        THEN("it remains empty and does not create a control block") {
+            REQUIRE(!obj);
+            REQUIRE(obj.use_count() == 0);
+            REQUIRE(MyClass::instances == 0);
+        }
+    }
+    REQUIRE(MyClass::instances == 0);
+}
+
+namespace {
+struct Container {
+    MyClass first;
+    MyClass second;
+    Container() : first(1), second(2) {}
+};
+} // namespace
+
+SCENARIO("std::shared_ptr aliasing constructor") {
+    GIVEN("A shared_ptr owning a Container with two MyClass members") {
+        MyClass::instances = 0;
+        auto owner = ETLSTD::make_shared<Container>();
+        REQUIRE(MyClass::instances == 2);
+
+        WHEN("an aliasing shared_ptr is built pointing at a member of owner") {
+            ETLSTD::shared_ptr<MyClass> alias(owner, &owner->second);
+
+            THEN("it points at the sub-object but shares ownership with owner") {
+                REQUIRE(alias.get() == &owner->second);
+                REQUIRE(alias->id == 2);
+                REQUIRE(owner.use_count() == 2);
+                REQUIRE(alias.use_count() == 2);
+            }
+
+            THEN("releasing owner keeps the aliased sub-object alive") {
+                owner.reset();
+                REQUIRE(MyClass::instances == 2);
+                REQUIRE(alias->id == 2);
+                REQUIRE(alias.use_count() == 1);
+
+                alias.reset();
+                REQUIRE(MyClass::instances == 0);
+            }
+        }
     }
     REQUIRE(MyClass::instances == 0);
 }

--- a/test/libstd/memory.cpp
+++ b/test/libstd/memory.cpp
@@ -86,16 +86,16 @@ SCENARIO("std::shared_ptr") {
         WHEN("ptr is copied twice") {
             auto obj2 = obj;
             auto obj3 = obj;
-            THEN("3 references are counted")
-            REQUIRE(obj.use_count() == 3);
+            THEN("references are counted and released correctly as owners give up their reference") {
+                REQUIRE(obj.use_count() == 3);
 
-            obj = nullptr;
-            THEN("ref count is decreased")
-            REQUIRE(obj2.use_count() == 2);
+                obj = nullptr;
+                REQUIRE(obj2.use_count() == 2);
 
-            obj3.reset();
-            REQUIRE(!obj3);
-            REQUIRE(obj2.unique());
+                obj3.reset();
+                REQUIRE(!obj3);
+                REQUIRE(obj2.unique());
+            }
         }
 
         WHEN("ptr is copy-assigned") {


### PR DESCRIPTION
Ports #88's fix onto current master (the original branch forked before
the AVR register-naming fix in d1162b6/#100, so its CI was red for
unrelated reasons).

Master's `shared_ptr::operator=` released the old resource, then
copied `rhs`'s `pointee`/`counter` directly without incrementing the
refcount -- a real double-free/use-after-free the moment both sides
went out of scope. It now uses copy-and-swap (build a temporary via
the copy constructor, swap it into `*this`), which keeps the refcount
consistent and handles self-assignment for free.

The converting copy constructor (`template<U> shared_ptr(const
shared_ptr<U>&)`) did `*this = ptr` on indeterminate `pointee`/
`counter` members (no member-init list) -- separately from the UB,
assigning a `shared_ptr<U>` where `operator=(const shared_ptr&)`
expects a `shared_ptr<T>` forces another conversion through the same
constructor. Gives it a member-init list like the same-type copy
constructor, and calls `inc()` directly.

`createCounter(nullptr)` used to allocate a control block for a null
pointee; now guarded so `shared_ptr<T>(nullptr)` stays a true empty
pointer with no allocation.

Quality pass on top of the original fix:
- Fixed two more `std::` hardcodings in this same file
  (`std::forward`, `std::nullptr_t`) -- the same bug class that broke
  the AVR build in 8051d39, just not yet exercised by CI here since
  `shared_ptr` isn't part of the avr-smoke target. Kept `ETLSTD::swap`
  qualified in `shared_ptr::swap()` specifically: an unqualified call
  there resolves to the member itself (wrong arity), since a class
  member of the same name hides the free function from ordinary
  lookup and suppresses ADL -- verified by building both ways.
- The branch's private aliasing constructor (shares refcount with one
  `shared_ptr` while pointing at a different sub-object) was unused
  and untested, and also inaccessible -- despite being private -- to
  the existing `static_pointer_cast`, which already called it. Made it
  public to match `std::shared_ptr`'s real API and added a test
  exercising actual aliasing semantics (pointing at a sub-object,
  verifying it survives the owner's release until the alias itself
  releases too).
- clang-format pass over both touched files.

Build + `ctest` pass with zero regressions.

Fixes #88