### PR TITLE
Validate embedded thread sleep semantics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(LIBSTD_HEADERS  libstd/include/algorithm libstd/include/array libstd/include
         libstd/include/iterator libstd/include/limits libstd/include/memory libstd/include/new libstd/include/queue libstd/include/random
         libstd/include/ratio libstd/include/stdexcept libstd/include/string libstd/include/thread libstd/include/tuple
         libstd/include/type_traits libstd/include/utility libstd/include/vector)
-set(LIBSTD_TESTS test/libstd/bitset.cpp test/libstd/chrono.cpp test/libstd/limits.cpp test/libstd/memory.cpp test/libstd/tuple.cpp test/libstd/type_traits.cpp
+set(LIBSTD_TESTS test/libstd/bitset.cpp test/libstd/chrono.cpp test/libstd/limits.cpp test/libstd/memory.cpp test/libstd/thread.cpp test/libstd/tuple.cpp test/libstd/type_traits.cpp
                  test/libstd/queue.cpp test/libstd/string.cpp test/libstd/string_view.cpp test/libstd/vector.cpp)
                  
 set(ETL_TESTS test/test.cpp test/SetClearTest.cpp test/InterruptsTest.cpp test/CircularBuffer.cpp)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Useful test runner commands:
 ```sh
 ./build/TestsETL --list-tests
 ./build/TestsETL '[GPIO]'
+./build/TestsETL '[thread]'
 ./build/TestsETL 'Scenario: std::tuple'
 ```
 

--- a/include/etl/architecture/ETLDevice_Mock.h
+++ b/include/etl/architecture/ETLDevice_Mock.h
@@ -19,7 +19,7 @@
 //     contributors may be used to endorse or promote products derived
 //     from this software without specific prior written permission.
 //
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS' 
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
 //  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 //  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
 //  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
@@ -34,63 +34,88 @@
 
 #include <thread>
 
-
 namespace etl {
 
-static uint16_t& GP0_OUT         = MockDevice::getInstance().registers[0];
-static uint16_t& GP1_OUT         = MockDevice::getInstance().registers[1];
-static uint16_t& GPSimuA_OUT     = MockDevice::getInstance().registers[2];
-static uint16_t& GPSimuB_OUT     = MockDevice::getInstance().registers[3];
-static uint16_t& GP0_IN          = MockDevice::getInstance().registers[4];
-static uint16_t& GP1_IN          = MockDevice::getInstance().registers[5];
-static uint16_t& GPSimuA_IN      = MockDevice::getInstance().registers[6];
-static uint16_t& GPSimuB_IN      = MockDevice::getInstance().registers[7];
-static uint16_t& GP0_DIR         = MockDevice::getInstance().registers[8];
-static uint16_t& GP1_DIR         = MockDevice::getInstance().registers[9];
-static uint16_t& GPSimuA_DIR     = MockDevice::getInstance().registers[10];
-static uint16_t& GPSimuB_DIR     = MockDevice::getInstance().registers[11];
-static uint16_t& GP0_OUT_SET     = MockDevice::getInstance().registers[12];
-static uint16_t& GP1_OUT_SET     = MockDevice::getInstance().registers[13];
-static uint16_t& GPSimuA_OUT_SET = MockDevice::getInstance().registers[14];
-static uint16_t& GPSimuB_OUT_SET = MockDevice::getInstance().registers[15];
-static uint16_t& GP0_OUT_CLR     = MockDevice::getInstance().registers[16];
-static uint16_t& GP1_OUT_CLR     = MockDevice::getInstance().registers[17];
-static uint16_t& GPSimuA_OUT_CLR = MockDevice::getInstance().registers[18];
-static uint16_t& GPSimuB_OUT_CLR = MockDevice::getInstance().registers[19];
-static uint16_t& GP0_DIR_SET     = MockDevice::getInstance().registers[20];
-static uint16_t& GP1_DIR_SET     = MockDevice::getInstance().registers[21];
-static uint16_t& GPSimuA_DIR_SET = MockDevice::getInstance().registers[22];
-static uint16_t& GPSimuB_DIR_SET = MockDevice::getInstance().registers[23];
-static uint16_t& GP0_DIR_CLR     = MockDevice::getInstance().registers[24];
-static uint16_t& GP1_DIR_CLR     = MockDevice::getInstance().registers[25];
-static uint16_t& GPSimuA_DIR_CLR = MockDevice::getInstance().registers[26];
-static uint16_t& GPSimuB_DIR_CLR = MockDevice::getInstance().registers[27];
+static uint16_t &GP0_OUT = MockDevice::getInstance().registers[0];
+static uint16_t &GP1_OUT = MockDevice::getInstance().registers[1];
+static uint16_t &GPSimuA_OUT = MockDevice::getInstance().registers[2];
+static uint16_t &GPSimuB_OUT = MockDevice::getInstance().registers[3];
+static uint16_t &GP0_IN = MockDevice::getInstance().registers[4];
+static uint16_t &GP1_IN = MockDevice::getInstance().registers[5];
+static uint16_t &GPSimuA_IN = MockDevice::getInstance().registers[6];
+static uint16_t &GPSimuB_IN = MockDevice::getInstance().registers[7];
+static uint16_t &GP0_DIR = MockDevice::getInstance().registers[8];
+static uint16_t &GP1_DIR = MockDevice::getInstance().registers[9];
+static uint16_t &GPSimuA_DIR = MockDevice::getInstance().registers[10];
+static uint16_t &GPSimuB_DIR = MockDevice::getInstance().registers[11];
+static uint16_t &GP0_OUT_SET = MockDevice::getInstance().registers[12];
+static uint16_t &GP1_OUT_SET = MockDevice::getInstance().registers[13];
+static uint16_t &GPSimuA_OUT_SET = MockDevice::getInstance().registers[14];
+static uint16_t &GPSimuB_OUT_SET = MockDevice::getInstance().registers[15];
+static uint16_t &GP0_OUT_CLR = MockDevice::getInstance().registers[16];
+static uint16_t &GP1_OUT_CLR = MockDevice::getInstance().registers[17];
+static uint16_t &GPSimuA_OUT_CLR = MockDevice::getInstance().registers[18];
+static uint16_t &GPSimuB_OUT_CLR = MockDevice::getInstance().registers[19];
+static uint16_t &GP0_DIR_SET = MockDevice::getInstance().registers[20];
+static uint16_t &GP1_DIR_SET = MockDevice::getInstance().registers[21];
+static uint16_t &GPSimuA_DIR_SET = MockDevice::getInstance().registers[22];
+static uint16_t &GPSimuB_DIR_SET = MockDevice::getInstance().registers[23];
+static uint16_t &GP0_DIR_CLR = MockDevice::getInstance().registers[24];
+static uint16_t &GP1_DIR_CLR = MockDevice::getInstance().registers[25];
+static uint16_t &GPSimuA_DIR_CLR = MockDevice::getInstance().registers[26];
+static uint16_t &GPSimuB_DIR_CLR = MockDevice::getInstance().registers[27];
 
 struct Pragma {
     Pragma(const std::string command) : paramsList(command) {}
-    Pragma& reg(const uint16_t& r)          { paramsList += " " + std::to_string(&r - &GP0_OUT); return *this; }
-    Pragma& bit(const uint8_t bitNumber)    { paramsList += " " + std::to_string(1<<bitNumber); return *this; }
-    Pragma& bitmask(const uint16_t bitmask) { paramsList += " " + std::to_string(bitmask); return *this; }
+    Pragma &reg(const uint16_t &r) {
+        paramsList += " " + std::to_string(&r - &GP0_OUT);
+        return *this;
+    }
+    Pragma &bit(const uint8_t bitNumber) {
+        paramsList += " " + std::to_string(1 << bitNumber);
+        return *this;
+    }
+    Pragma &bitmask(const uint16_t bitmask) {
+        paramsList += " " + std::to_string(bitmask);
+        return *this;
+    }
 
     std::string paramsList;
 };
 class Device {
 public:
-    static int64_t pragma(const Pragma& param) { return MockDevice::getInstance().pragma(param.paramsList); }
-    static int64_t pragma(std::string pragma)  { return MockDevice::getInstance().pragma(pragma); }
-    static void initialize()                   { MockDevice::getInstance().configure(NB_PORTS); }
-    static void delay_us(uint32_t us)          { std::this_thread::sleep_for(std::chrono::microseconds(us)); }
-    static void delay_ms(uint32_t ms)          { std::this_thread::sleep_for(std::chrono::milliseconds(ms)); }
-    static void yield()                        { MockDevice::getInstance().yield(); }
-    static void addOnChangeCallback(const std::function<void()> handler, uint16_t& triggerRegister, uint16_t mask) {
+    static int64_t pragma(const Pragma &param) { return MockDevice::getInstance().pragma(param.paramsList); }
+    static int64_t pragma(std::string pragma) { return MockDevice::getInstance().pragma(pragma); }
+    static void initialize() { MockDevice::getInstance().configure(NB_PORTS); }
+    static void delayTicks(uint32_t ticks) {
+        lastDelayTicks_ = ticks;
+        totalDelayTicks_ += ticks;
+
+        const auto micros = (static_cast<uint64_t>(ticks) * 1000000ULL + (McuFrequency - 1)) / McuFrequency;
+        if (micros > 0) {
+            std::this_thread::sleep_for(std::chrono::microseconds(micros));
+        }
+    }
+    static void delay_us(uint32_t us) { std::this_thread::sleep_for(std::chrono::microseconds(us)); }
+    static void delay_ms(uint32_t ms) { std::this_thread::sleep_for(std::chrono::milliseconds(ms)); }
+    static void yield() { MockDevice::getInstance().yield(); }
+    static void addOnChangeCallback(const std::function<void()> handler, uint16_t &triggerRegister, uint16_t mask) {
         auto index = &triggerRegister - MockDevice::getInstance().registers.data();
         MockDevice::getInstance().addOnChangeCallback(handler, index, mask);
     }
 
-    static void removeOnChangeCallback(uint16_t& triggerRegister, uint16_t mask) {
+    static void removeOnChangeCallback(uint16_t &triggerRegister, uint16_t mask) {
         auto index = &triggerRegister - MockDevice::getInstance().registers.data();
         MockDevice::getInstance().clearAddOnChangeCallback(index, mask);
     }
+
+    static void resetDelayTicksLog() {
+        lastDelayTicks_ = 0;
+        totalDelayTicks_ = 0;
+    }
+
+    static uint32_t lastDelayTicks() { return lastDelayTicks_; }
+    static uint64_t totalDelayTicks() { return totalDelayTicks_; }
 
     static const size_t flashSize = 65535;
     static const size_t sramSize = 10000;
@@ -105,6 +130,10 @@ public:
     static const uint8_t OUT_REG_CYCLES = 3;
     static const uint8_t OUTCLR_REG_CYCLES = 1;
     static const uint8_t OUTSET_REG_CYCLES = 1;
+
+private:
+    inline static uint32_t lastDelayTicks_ = 0;
+    inline static uint64_t totalDelayTicks_ = 0;
 };
 
 } // namespace etl

--- a/libstd/include/thread
+++ b/libstd/include/thread
@@ -40,14 +40,19 @@ namespace this_thread {
 
 using clock_cycles = chrono::duration<unsigned long, ratio<1, etl::Device::McuFrequency>>;
 
-/// Blocks the execution of the current thread for the specified constant sleepDuration with a 1 cycle resolution.
-/// On mock targets this goes through Device::delayTicks so tests can observe the requested cycle count.
+/// Blocks the execution of the current thread for the specified sleepDuration with a 1 cycle resolution.
+/// Overload resolution picks this version whenever sleepDuration cannot bind to a mutable (non-const)
+/// lvalue reference, i.e. for rvalues such as literals (e.g. sleep_for(2ms)) and for const-qualified
+/// duration variables. On mock targets this goes through Device::delayTicks so tests can observe the
+/// requested cycle count.
 template <typename Rep, typename Period> constexpr void sleep_for(const chrono::duration<Rep, Period> &sleepDuration) {
     etl::Device::delayTicks(chrono::duration_cast<clock_cycles>(sleepDuration).count());
 }
 
 /// Blocks the execution of the current thread for the specified sleepDuration with a 1 millisecond resolution.
-/// Non-constexpr durations are rounded to whole milliseconds and compensate a small fixed loop overhead.
+/// Overload resolution picks this version only when sleepDuration is passed as a mutable (non-const) lvalue,
+/// e.g. `auto d = 2ms; sleep_for(d);` — rvalues and const-qualified durations bind to the overload above
+/// instead. The duration is rounded to whole milliseconds and a small fixed loop overhead is compensated for.
 template <typename Rep, typename Period> void sleep_for(chrono::duration<Rep, Period> &sleepDuration) {
     uint32_t nbMs = chrono::duration_cast<chrono::milliseconds>(sleepDuration).count();
     const auto ticksPerMs = chrono::duration_cast<clock_cycles>(1ms).count() - (64 / etl::Device::architectureWidth);

--- a/libstd/readme.md
+++ b/libstd/readme.md
@@ -22,3 +22,5 @@ This bundled library is intentionally partial. It primarily covers the following
 - `<utility>`
 - `<array>`
 - `<exception>`
+
+`<thread>` is part of the evolving embedded subset: `this_thread::sleep_for` is supported as a timing helper when the target `Device` exposes `delayTicks`, and mock validation should treat it as a cycle-accounted delay rather than as a high-precision wall-clock guarantee.

--- a/test/libstd/thread.cpp
+++ b/test/libstd/thread.cpp
@@ -1,9 +1,9 @@
-/// @file thread
-/// @data 13/06/2016 18:23:53
+/// @file test/libstd/thread.cpp
+/// @date 01/07/2026
 /// @author Ambroise Leclerc
-/// @brief this header is part of the thread support library.
+/// @brief Tests for <thread>
 //
-// Copyright (c) 2016, Ambroise Leclerc
+// Copyright (c) 2026, Ambroise Leclerc
 //   All rights reserved.
 //
 //   Redistribution and use in source and binary forms, with or without
@@ -30,31 +30,35 @@
 //  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 //  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 //  POSSIBILITY OF SUCH DAMAGE.
-#pragma once
+#include <catch.hpp>
+
+#define __Mock_Mock__
+#define ETLSTD etlstd
 
 #include <etl/ioports.h>
-#include <libstd/include/chrono>
+#include <libstd/include/thread>
 
-namespace ETLSTD {
-namespace this_thread {
+using namespace ETLSTD;
+using namespace ETLSTD::chrono_literals;
 
-using clock_cycles = chrono::duration<unsigned long, ratio<1, etl::Device::McuFrequency>>;
+SCENARIO("std::this_thread::sleep_for constant-duration path", "[libstd][thread]") {
+    etl::Device::resetDelayTicksLog();
+    using clock_cycles = ETLSTD::chrono::duration<unsigned long, ETLSTD::ratio<1, etl::Device::McuFrequency>>;
 
-/// Blocks the execution of the current thread for the specified constant sleepDuration with a 1 cycle resolution.
-/// On mock targets this goes through Device::delayTicks so tests can observe the requested cycle count.
-template <typename Rep, typename Period> constexpr void sleep_for(const chrono::duration<Rep, Period> &sleepDuration) {
-    etl::Device::delayTicks(chrono::duration_cast<clock_cycles>(sleepDuration).count());
+    ETLSTD::this_thread::sleep_for(3us);
+
+    REQUIRE(etl::Device::lastDelayTicks() == chrono::duration_cast<clock_cycles>(3us).count());
+    REQUIRE(etl::Device::totalDelayTicks() == etl::Device::lastDelayTicks());
 }
 
-/// Blocks the execution of the current thread for the specified sleepDuration with a 1 millisecond resolution.
-/// Non-constexpr durations are rounded to whole milliseconds and compensate a small fixed loop overhead.
-template <typename Rep, typename Period> void sleep_for(chrono::duration<Rep, Period> &sleepDuration) {
-    uint32_t nbMs = chrono::duration_cast<chrono::milliseconds>(sleepDuration).count();
+SCENARIO("std::this_thread::sleep_for millisecond runtime path", "[libstd][thread]") {
+    etl::Device::resetDelayTicksLog();
+    using clock_cycles = ETLSTD::chrono::duration<unsigned long, ETLSTD::ratio<1, etl::Device::McuFrequency>>;
+
+    auto duration = 2ms;
+    ETLSTD::this_thread::sleep_for(duration);
+
     const auto ticksPerMs = chrono::duration_cast<clock_cycles>(1ms).count() - (64 / etl::Device::architectureWidth);
-    for (auto count = nbMs; count > 0; count--) {
-        etl::Device::delayTicks(ticksPerMs);
-    }
+    REQUIRE(etl::Device::lastDelayTicks() == ticksPerMs);
+    REQUIRE(etl::Device::totalDelayTicks() == static_cast<uint64_t>(ticksPerMs) * 2);
 }
-
-} // namespace this_thread
-} // namespace ETLSTD


### PR DESCRIPTION
## Summary
- `libstd/include/thread` referenced `etl::clock_cycles` and `etl::Device::delayTicks`, neither of which exists for the Mock/host target — the header was silently never compiled, since `test/test.cpp`'s only `#include` of it sits inside a commented-out block.
- Define `clock_cycles` locally in `ETLSTD::this_thread` from `etl::Device::McuFrequency`, instead of relying on the per-architecture `etl::clock_cycles` alias that AVR/ESP ioports headers define but the mock target doesn't.
- Add `delayTicks` to `ETLDevice_Mock.h` (plus a small tick-count log used only by tests). It converts the requested tick count to microseconds and forwards to `std::this_thread::sleep_for`, consistent with how `delay_us`/`delay_ms` already behave on the mock target.
- Added `test/libstd/thread.cpp`, registered in `LIBSTD_TESTS`, covering both `sleep_for` overloads (constant-duration and millisecond-runtime paths) by asserting the tick counts `delayTicks` receives. Requested delays are single-digit milliseconds, so the test suite stays fast (verified: full suite still runs in ~0.01s).

Rebased onto current master (which contains the AVR ioports fix from #100); original branch was forked before that fix and had an unrelated red CI.

## Test plan
- [x] `cmake -S . -B build && cmake --build build -j$(nproc)`
- [x] `ctest --test-dir build --output-on-failure` — all tests pass
- [x] `./build/TestsETL '[thread]' --success` — both scenarios pass with expected tick counts

Fixes #98