### PR TITLE
Define libstd support policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,7 @@
 - `include/etl/ioports.h` is the target-selection layer. It chooses an implementation from `include/etl/architecture/` based on preprocessor macros such as `__AVR_*__`, `__ESP_*__`, or `__Mock_Mock__`.
 - The core API is built around static port/pin types instead of runtime objects. `PortN` and `PinN` classes expose operations like `set`, `clear`, `setOutput`, and `changeBits`, plus compile-time metadata like `Pin::Port`, `Pin::bit()`, and `Pin::bitmask()`. The README's RGB LED examples reflect this compile-time composition model.
 - `libstd/include/` is ETL's bundled standard-library subset for targets that do not provide a usable C++ standard library. ETL code uses the `ETLSTD` namespace alias so the same headers can work with host `std` or bundled `etlstd`.
+- `libstd/readme.md` defines a support policy for bundled headers: some are **supported**, some are **experimental**, and some remain **placeholder** headers. Do not assume every header under `libstd/include/` is equally mature.
 - `CMakeLists.txt` now separates the host test runner from the AVR smoke build. The AVR path is a compile/link validation target, not a flashed firmware application.
 - Host-side tests run against the mock architecture in `include/etl/architecture/MockCore.h` and `test/MockDevice.h`. `Device::yield()` is the central simulation step: it flushes staged register writes, applies `Device::pragma("BitLink" ...)` wiring, and dispatches pin-change callbacks.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ ETL now targets a single **C++23** baseline across the repository:
 
 The bundled `libstd` directory remains a focused compatibility layer for the subset of standard-library facilities ETL uses on embedded targets; it is not a full reimplementation of the entire C++23 standard library.
 
-Within `libstd`, ETL now distinguishes between **supported**, **experimental**, and **placeholder** headers. The detailed support matrix lives in `libstd/readme.md`; in short, low-level headers ETL already depends on are maintained, `vector`/`random`/`thread`/`memory` are experimental (the latter has a known `shared_ptr` reference-counting bug), and `string`/`tuple` are placeholders not yet fit for use.
+Within `libstd`, ETL now distinguishes between **supported**, **experimental**, and **placeholder** headers. The detailed support matrix lives in `libstd/readme.md`; in short, low-level headers ETL already depends on are maintained, `vector`/`random`/`thread`/`memory` are experimental (`memory` has a known `shared_ptr` reference-counting bug), and `string`/`tuple` are placeholders not yet fit for use.
 
 
 Host-side build and tests

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ ETL now targets a single **C++23** baseline across the repository:
 
 The bundled `libstd` directory remains a focused compatibility layer for the subset of standard-library facilities ETL uses on embedded targets; it is not a full reimplementation of the entire C++23 standard library.
 
+Within `libstd`, ETL now distinguishes between **supported**, **experimental**, and **placeholder** headers. The detailed support matrix lives in `libstd/readme.md`; in short, low-level headers ETL already depends on are maintained, `vector`/`random`/`thread`/`memory` are experimental (the latter has a known `shared_ptr` reference-counting bug), and `string`/`tuple` are placeholders not yet fit for use.
+
 
 Host-side build and tests
 =========================

--- a/libstd/readme.md
+++ b/libstd/readme.md
@@ -28,7 +28,7 @@ Current classification:
 | `memory` | Experimental | `unique_ptr`/`make_unique` are solid, but `shared_ptr`'s copy assignment does not increment the reference count, an unfixed use-after-free/double-free risk (issue #88); do not rely on `shared_ptr` copies yet. |
 | `string`, `tuple` | Placeholder | Present in the tree, but not yet strong enough to be treated as part of the supported subset. |
 
-If a header is not explicitly listed as supported, prefer to treat it as non-contractual until its status is promoted.
+Any header not present in the classification table above should be treated as non-contractual until it is added and given a status.
 
 This bundled library is intentionally partial. It primarily covers the following families of facilities that ETL relies on:
 

--- a/libstd/readme.md
+++ b/libstd/readme.md
@@ -8,6 +8,28 @@ A bundled standard-library subset for ETL.
 
 When ETL is consumed from another build system, add both the repository root and `include/` to the compiler include path. ETL headers refer to bundled headers through paths such as `libstd/include/memory`, so `include/` alone is not enough.
 
+Support policy
+==============
+
+The bundled `libstd` surface is intentionally smaller than the hosted standard library. Headers in this directory fall into three categories:
+
+| Status | Meaning |
+| --- | --- |
+| **Supported** | ETL relies on this header directly, it is part of the maintained embedded subset, and it should have active tests or compile validation. |
+| **Experimental** | The header is being developed as an embedded-oriented subset, but the API and behavioral contract are still narrower or less stable than the hosted standard library. |
+| **Placeholder** | The header exists for roadmap or compatibility reasons but should not be treated as part of the supported ETL surface yet. |
+
+Current classification:
+
+| Header family | Status | Notes |
+| --- | --- | --- |
+| `utility`, `type_traits`, `cstddef`, `cstdint`, `limits`, `ratio`, `chrono`, `iterator`, `array`, `bitset`, `functional`, `queue`, `string_view`, `exception`, `stdexcept`, `initializer_list`, `new` | Supported | These headers are part of the maintained embedded subset and are expected to stay usable under the current C++23 baseline. |
+| `thread`, `vector`, `random` | Experimental | Present and exercised, but still evolving toward a clearer embedded contract and deeper validation. `random` currently offers only `xorshift32_engine` and `uniform_int_distribution`, a small modulo-biased embedded subset, not a full `<random>` implementation. |
+| `memory` | Experimental | `unique_ptr`/`make_unique` are solid, but `shared_ptr`'s copy assignment does not increment the reference count, an unfixed use-after-free/double-free risk (issue #88); do not rely on `shared_ptr` copies yet. |
+| `string`, `tuple` | Placeholder | Present in the tree, but not yet strong enough to be treated as part of the supported subset. |
+
+If a header is not explicitly listed as supported, prefer to treat it as non-contractual until its status is promoted.
+
 This bundled library is intentionally partial. It primarily covers the following families of facilities that ETL relies on:
 
 - `new`, `delete`, `new[]`, `delete[]`, placement new and delete operators


### PR DESCRIPTION
Adds a Supported/Experimental/Placeholder maturity table to
`libstd/readme.md`, a summary note in `README.md`, and a pointer in
`.github/copilot-instructions.md`, so consumers and future agents don't
assume every `libstd/include/` header is equally mature.

The classification was checked against the current state of each header
on master plus the fixes already landed via other open `rebase/issue-*`
PRs, rather than blindly porting Copilot's original table:

- `string_view`, `random`, `functional`, `array`, `queue` reflect the
  real fixes already open in #86/#94/#95/#96/#89's PRs. `random` lands as
  **Experimental** (real and tested now, but only a narrow modulo-biased
  `xorshift32_engine` + `uniform_int_distribution` subset), not Supported.
- `memory` is downgraded from Copilot's original "Supported" claim to
  **Experimental**: on master today, `shared_ptr`'s copy assignment does
  not increment the reference count (`operator=` releases and reassigns
  `pointee`/`counter` without calling `counter->inc()`), a real unfixed
  use-after-free/double-free risk tracked by issue #88, which has no PR
  yet. `unique_ptr`/`make_unique` are unaffected and solid.
- `string`, `tuple` remain **Placeholder** pending #92 and #93, which
  also have no PR open yet.

Note: `rebase/issue-94-random`'s PR (#106) opportunistically added the
same support-policy table to `libstd/readme.md` before this issue landed;
that overlap will need a small conflict resolution whichever of the two
merges second.

Rebased onto current master (past PR #100, which fixed unrelated AVR
register-naming build failures this branch's CI was blocked on). Docs-only
change; build and full test suite still pass with zero regressions.

Fixes #91